### PR TITLE
Implement timeout logic with retries

### DIFF
--- a/tests/test_web3_service.py
+++ b/tests/test_web3_service.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import MagicMock
+
+from web3.exceptions import TimeExhausted
+from web3_service import Web3Service, TransactionFailedError, TransactionTimeoutError
+
+
+def _mock_service() -> Web3Service:
+    service = Web3Service.__new__(Web3Service)
+    service.web3 = MagicMock()
+    service.account = MagicMock(address="0xabc", key="key")
+    service.web3.eth.get_transaction_count.return_value = 1
+    service.web3.eth.account.sign_transaction.return_value = MagicMock(rawTransaction=b"tx")
+    return service
+
+
+def test_sign_and_send_success():
+    service = _mock_service()
+    receipt = {"status": 1}
+    service.web3.eth.send_raw_transaction.return_value = b"hash"
+    service.web3.eth.wait_for_transaction_receipt.return_value = receipt
+
+    result = service.sign_and_send_transaction({})
+    assert result is receipt
+
+
+def test_sign_and_send_failure_status_zero():
+    service = _mock_service()
+    receipt = {"status": 0}
+    service.web3.eth.send_raw_transaction.return_value = b"hash"
+    service.web3.eth.wait_for_transaction_receipt.return_value = receipt
+
+    with pytest.raises(TransactionFailedError):
+        service.sign_and_send_transaction({})
+
+
+def test_sign_and_send_timeout_then_raises():
+    service = _mock_service()
+    service.web3.eth.send_raw_transaction.return_value = b"hash"
+    service.web3.eth.wait_for_transaction_receipt.side_effect = TimeExhausted
+
+    with pytest.raises(TransactionTimeoutError):
+        service.sign_and_send_transaction({}, timeout=0.1, retries=2)
+
+
+def test_sign_and_send_timeout_then_success():
+    service = _mock_service()
+    receipt = {"status": 1}
+    service.web3.eth.send_raw_transaction.return_value = b"hash"
+    service.web3.eth.wait_for_transaction_receipt.side_effect = [TimeExhausted, receipt]
+
+    result = service.sign_and_send_transaction({}, timeout=0.1, retries=2)
+    assert result is receipt


### PR DESCRIPTION
## Summary
- add custom `TransactionTimeoutError`
- implement timeout and retry handling in `Web3Service.sign_and_send_transaction`
- adjust middleware import for Web3 v7 compatibility
- add unit tests covering transaction retries

## Testing
- `PYTHONPATH=. pytest --cov=web3_service tests/test_web3_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b26bafa4c8322b0a06928c41bd3ab