### PR TITLE
Make price retrieval and strategy async

### DIFF
--- a/dex_handler.py
+++ b/dex_handler.py
@@ -8,6 +8,7 @@ swaps on DEXs that follow the Uniswap V2 protocol.
 """
 
 import time
+import asyncio
 from typing import List, Dict, Any, Final
 
 from web3.contract import Contract
@@ -64,7 +65,7 @@ class DEXHandler:
             router_address, UNISWAP_V2_ROUTER_ABI
         )
 
-    def get_price(
+    async def get_price(
         self,
         token_in_address: str,
         token_out_address: str,
@@ -84,9 +85,9 @@ class DEXHandler:
         """
         try:
             path = [token_in_address, token_out_address]
-            amounts_out = self.contract.functions.getAmountsOut(
-                amount_in, path
-            ).call()
+            amounts_out = await asyncio.to_thread(
+                self.contract.functions.getAmountsOut(amount_in, path).call
+            )
             # Assuming the output token has 18 decimals, a common standard
             return amounts_out[1] / (10**18)
         except (ContractLogicError, ValueError):

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ selected trading strategy.
 """
 
 from typing import List
+import asyncio
 
 import config
 from web3_service import Web3Service
@@ -35,7 +36,7 @@ def main() -> None:
 
         # 3. Initialize and run the trading strategy
         strategy = ArbitrageStrategy(dex_handlers)
-        strategy.run()
+        asyncio.run(strategy.run())
 
     except (ValueError, ConnectionError) as e:
         print(f"Initialization failed: {e}")

--- a/strategy.py
+++ b/strategy.py
@@ -7,7 +7,7 @@ This module contains the logic for identifying and acting upon
 trading opportunities based on market conditions.
 """
 
-import time
+import asyncio
 from typing import List
 
 import config
@@ -67,7 +67,7 @@ class ArbitrageStrategy:
         else:
             print("No profitable opportunity found. Standing by.")
 
-    def run(self) -> None:
+    async def run(self) -> None:
         """
         Starts the main trading loop for the strategy.
         """
@@ -80,8 +80,8 @@ class ArbitrageStrategy:
         while True:
             try:
                 # Get price of 1 WETH in DAI on both exchanges
-                price_dex1 = self.dex1.get_price(self.token0, self.token1)
-                price_dex2 = self.dex2.get_price(self.token0, self.token1)
+                price_dex1 = await self.dex1.get_price(self.token0, self.token1)
+                price_dex2 = await self.dex2.get_price(self.token0, self.token1)
 
                 if price_dex1 > 0 and price_dex2 > 0:
                     self._check_profitability(price_dex1, price_dex2)
@@ -92,4 +92,4 @@ class ArbitrageStrategy:
                 print(f"An error occurred: {e}")
 
             print(f"Waiting for {config.POLL_INTERVAL_SECONDS} seconds...")
-            time.sleep(config.POLL_INTERVAL_SECONDS)
+            await asyncio.sleep(config.POLL_INTERVAL_SECONDS)

--- a/tests/test_async_functions.py
+++ b/tests/test_async_functions.py
@@ -1,0 +1,71 @@
+import os
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+os.environ.setdefault("RPC_URL", "http://localhost")
+os.environ.setdefault("PRIVATE_KEY", "test")
+os.environ.setdefault("WALLET_ADDRESS", "addr")
+
+from dex_handler import DEXHandler
+from strategy import ArbitrageStrategy
+
+
+@pytest.mark.asyncio
+async def test_get_price_success(monkeypatch):
+    handler = DEXHandler.__new__(DEXHandler)
+    handler.contract = MagicMock()
+
+    call_mock = MagicMock(return_value=[10**18, 2 * 10**18])
+    func_mock = MagicMock(return_value=MagicMock(call=call_mock))
+    handler.contract.functions.getAmountsOut = func_mock
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    price = await handler.get_price("a", "b")
+    assert price == 2.0
+
+
+@pytest.mark.asyncio
+async def test_get_price_error(monkeypatch):
+    handler = DEXHandler.__new__(DEXHandler)
+    handler.contract = MagicMock()
+
+    call_mock = MagicMock(side_effect=ValueError("fail"))
+    func_mock = MagicMock(return_value=MagicMock(call=call_mock))
+    handler.contract.functions.getAmountsOut = func_mock
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    price = await handler.get_price("a", "b")
+    assert price == 0.0
+
+
+@pytest.mark.asyncio
+async def test_arbitrage_run_once(monkeypatch):
+    dex1 = MagicMock()
+    dex2 = MagicMock()
+    dex1.router_address = "dex1"
+    dex2.router_address = "dex2"
+    dex1.get_price = AsyncMock(return_value=1.0)
+    dex2.get_price = AsyncMock(return_value=2.0)
+
+    strategy = ArbitrageStrategy([dex1, dex2])
+    strategy._check_profitability = MagicMock()
+
+    async def stop_sleep(_):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(asyncio, "sleep", stop_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await strategy.run()
+
+    strategy._check_profitability.assert_called_with(1.0, 2.0)

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -1,0 +1,27 @@
+import os
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import main
+
+
+def test_main_runs(monkeypatch):
+    os.environ.setdefault("RPC_URL", "http://localhost")
+    os.environ.setdefault("PRIVATE_KEY", "key")
+    os.environ.setdefault("WALLET_ADDRESS", "addr")
+
+    monkeypatch.setattr(main, "Web3Service", MagicMock())
+    monkeypatch.setattr(main, "DEXHandler", MagicMock())
+
+    strategy = MagicMock()
+    strategy.run = AsyncMock()
+    monkeypatch.setattr(main, "ArbitrageStrategy", MagicMock(return_value=strategy))
+
+    def fake_run(coro):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(coro)
+
+    monkeypatch.setattr(main, "asyncio", MagicMock(run=fake_run))
+
+    main.main()
+    strategy.run.assert_awaited_once()


### PR DESCRIPTION
## Summary
- make `DEXHandler.get_price` asynchronous
- run the arbitrage strategy in an async loop
- invoke `asyncio.run` from `main.py`
- add async tests for strategy, price retrieval and main

## Testing
- `PYTHONPATH=. pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2816c30c832296706f5d347e88ad