### PR TITLE
Add env-based token and router config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ RPC_URL="YOUR_RPC_URL_HERE"
 # This key gives full control over your funds. 
 PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY_HERE" 
 WALLET_ADDRESS="YOUR_WALLET_PUBLIC_ADDRESS_HERE"
+
+# Token and DEX configuration
+TOKEN0_ADDRESS="0xYourToken0"
+TOKEN1_ADDRESS="0xYourToken1"
+UNISWAP_V2_ROUTER="0xUniswapRouter"
+SUSHISWAP_ROUTER="0xSushiswapRouter"

--- a/README.md
+++ b/README.md
@@ -87,9 +87,19 @@ Create a .env file in the project's root directory. You can copy the .env.exampl
 • It is highly recommended to use a new, dedicated "hot wallet" for this bot with a limited amount of funds.
 Your .env file should look like this:
 ```
-# Ethereum Node RPC URL from a provider like Infura or Alchemy RPC_URL="YOUR_RPC_URL_HERE" 
-# Wallet credentials 
-# WARNING: This is your private key. Keep it secret, keep it safe. PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY_HERE" WALLET_ADDRESS="YOUR_WALLET_PUBLIC_ADDRESS_HERE"
+# Ethereum Node RPC URL from a provider like Infura or Alchemy
+RPC_URL="YOUR_RPC_URL_HERE"
+
+# Wallet credentials
+# WARNING: This is your private key. Keep it secret, keep it safe.
+PRIVATE_KEY="YOUR_WALLET_PRIVATE_KEY_HERE"
+WALLET_ADDRESS="YOUR_WALLET_PUBLIC_ADDRESS_HERE"
+
+# Token and DEX configuration
+TOKEN0_ADDRESS="0xYourToken0"
+TOKEN1_ADDRESS="0xYourToken1"
+UNISWAP_V2_ROUTER="0xUniswapRouter"
+SUSHISWAP_ROUTER="0xSushiswapRouter"
 ```
 
 ▶️ Usage

--- a/config.py
+++ b/config.py
@@ -38,14 +38,22 @@ if not WALLET_ADDRESS:
 
 # --- Trading Pair Configuration ---
 # Addresses of the tokens to be traded.
-# Example uses WETH and DAI.
-TOKEN0_ADDRESS: Final[str] = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" # WETH
-TOKEN1_ADDRESS: Final[str] = "0x6B175474E89094C44Da98b954EedeAC495271d0F" # DAI
+# Values must be provided via environment variables.
+def _load_address(var_name: str) -> str:
+    address = os.getenv(var_name, "").strip()
+    if not address:
+        raise ConfigurationError(f"{var_name} environment variable not set.")
+    if not (address.startswith("0x") and len(address) == 42):
+        raise ConfigurationError(f"{var_name} is not a valid address.")
+    return address
+
+TOKEN0_ADDRESS: Final[str] = _load_address("TOKEN0_ADDRESS")
+TOKEN1_ADDRESS: Final[str] = _load_address("TOKEN1_ADDRESS")
 
 # --- DEX Configuration ---
 # Contract addresses for Uniswap V2 and Sushiswap Routers.
-UNISWAP_V2_ROUTER: Final[str] = "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D"
-SUSHISWAP_ROUTER: Final[str] = "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F"
+UNISWAP_V2_ROUTER: Final[str] = _load_address("UNISWAP_V2_ROUTER")
+SUSHISWAP_ROUTER: Final[str] = _load_address("SUSHISWAP_ROUTER")
 
 DEX_ROUTERS: Final[List[str]] = [UNISWAP_V2_ROUTER, SUSHISWAP_ROUTER]
 

--- a/tests/test_async_functions.py
+++ b/tests/test_async_functions.py
@@ -7,6 +7,10 @@ import pytest
 os.environ.setdefault("RPC_URL", "http://localhost")
 os.environ.setdefault("PRIVATE_KEY", "test")
 os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
+os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
+os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
+os.environ.setdefault("SUSHISWAP_ROUTER", "0x0000000000000000000000000000000000000004")
 
 from dex_handler import DEXHandler
 from strategy import ArbitrageStrategy

--- a/tests/test_custom_exceptions.py
+++ b/tests/test_custom_exceptions.py
@@ -1,4 +1,12 @@
 import os
+os.environ.setdefault("RPC_URL", "http://localhost")
+os.environ.setdefault("PRIVATE_KEY", "key")
+os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
+os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
+os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
+os.environ.setdefault("SUSHISWAP_ROUTER", "0x0000000000000000000000000000000000000004")
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,10 +15,6 @@ from exceptions import DexError, StrategyError
 from dex_handler import DEXHandler
 from web3_service import TransactionFailedError
 from strategy import ArbitrageStrategy
-
-os.environ.setdefault("RPC_URL", "http://localhost")
-os.environ.setdefault("PRIVATE_KEY", "key")
-os.environ.setdefault("WALLET_ADDRESS", "addr")
 
 
 def test_strategy_error_raised():

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -1,4 +1,12 @@
 import os
+os.environ.setdefault("RPC_URL", "http://localhost")
+os.environ.setdefault("PRIVATE_KEY", "key")
+os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
+os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
+os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
+os.environ.setdefault("SUSHISWAP_ROUTER", "0x0000000000000000000000000000000000000004")
+
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 


### PR DESCRIPTION
## Summary
- load token and router contract addresses from environment variables
- update example `.env` with token and router placeholders
- document new configuration variables in README
- update tests to set the new environment variables

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b37158ab483229beb73f34b09f17e