### PR TITLE
Add test config and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,25 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+      - name: Run tests
+        run: |
+          pytest --cov=./

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 web3
 python-dotenv
+pytest
+pytest-asyncio
+pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for test imports
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Set default environment variables to satisfy config loading
+os.environ.setdefault("RPC_URL", "http://localhost")
+os.environ.setdefault("PRIVATE_KEY", "test")
+os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
+os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
+os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
+os.environ.setdefault("SUSHISWAP_ROUTER", "0x0000000000000000000000000000000000000004")


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding `conftest.py`
- install pytest tools in `requirements.txt`
- run tests automatically with GitHub Actions

## Testing
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_684b386b181883229b37ea7bdfbc1b30