### PR TITLE
Improve config validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,9 @@ from environment variables.
 """
 
 import os
-from typing import List, Final
+from typing import Final, List
+
+from web3 import Web3
 
 from exceptions import ConfigurationError
 
@@ -17,6 +19,45 @@ from dotenv import load_dotenv
 
 # --- Load environment variables from .env file ---
 load_dotenv()
+
+
+def _load_address(var_name: str) -> str:
+    """Load and validate an Ethereum address from the environment."""
+    address = os.getenv(var_name, "").strip()
+    if not address:
+        raise ConfigurationError(f"{var_name} environment variable not set.")
+    if not Web3.isAddress(address):
+        raise ConfigurationError(f"{var_name} is not a valid Ethereum address.")
+    return Web3.toChecksumAddress(address)
+
+
+def _load_float(var_name: str, default: float, *, minimum: float, maximum: float) -> float:
+    """Load a float from the environment with range validation."""
+    value_str = os.getenv(var_name, str(default))
+    try:
+        value = float(value_str)
+    except ValueError as exc:
+        raise ConfigurationError(f"{var_name} must be a number.") from exc
+    if not minimum <= value <= maximum:
+        raise ConfigurationError(
+            f"{var_name} must be between {minimum} and {maximum}."
+        )
+    return value
+
+
+def _load_int(var_name: str, default: int, *, minimum: int, maximum: int) -> int:
+    """Load an int from the environment with range validation."""
+    value_str = os.getenv(var_name, str(default))
+    try:
+        value = int(value_str)
+    except ValueError as exc:
+        raise ConfigurationError(f"{var_name} must be an integer.") from exc
+    if not minimum <= value <= maximum:
+        raise ConfigurationError(
+            f"{var_name} must be between {minimum} and {maximum}."
+        )
+    return value
+
 
 # --- Security & Connection Configuration ---
 # A secure RPC URL from a provider like Infura or Alchemy is required.
@@ -32,21 +73,11 @@ if not PRIVATE_KEY:
     raise ConfigurationError("PRIVATE_KEY environment variable not set.")
 
 # The public address of the trading wallet.
-WALLET_ADDRESS: Final[str] = os.getenv("WALLET_ADDRESS", "")
-if not WALLET_ADDRESS:
-    raise ConfigurationError("WALLET_ADDRESS environment variable not set.")
+WALLET_ADDRESS: Final[str] = _load_address("WALLET_ADDRESS")
 
 # --- Trading Pair Configuration ---
 # Addresses of the tokens to be traded.
 # Values must be provided via environment variables.
-def _load_address(var_name: str) -> str:
-    address = os.getenv(var_name, "").strip()
-    if not address:
-        raise ConfigurationError(f"{var_name} environment variable not set.")
-    if not (address.startswith("0x") and len(address) == 42):
-        raise ConfigurationError(f"{var_name} is not a valid address.")
-    return address
-
 TOKEN0_ADDRESS: Final[str] = _load_address("TOKEN0_ADDRESS")
 TOKEN1_ADDRESS: Final[str] = _load_address("TOKEN1_ADDRESS")
 
@@ -59,10 +90,16 @@ DEX_ROUTERS: Final[List[str]] = [UNISWAP_V2_ROUTER, SUSHISWAP_ROUTER]
 
 # --- Bot Operational Parameters ---
 # The minimum profit threshold in TOKEN1 (e.g., DAI) to execute a trade.
-PROFIT_THRESHOLD: Final[float] = 1.0  # e.g., 1 DAI
+PROFIT_THRESHOLD: Final[float] = _load_float(
+    "PROFIT_THRESHOLD", 1.0, minimum=0.0, maximum=1000.0
+)
 
 # Time in seconds to wait between polling for prices.
-POLL_INTERVAL_SECONDS: Final[int] = 10
+POLL_INTERVAL_SECONDS: Final[int] = _load_int(
+    "POLL_INTERVAL_SECONDS", 10, minimum=1, maximum=3600
+)
 
 # Maximum acceptable slippage for trades, in percentage.
-SLIPPAGE_TOLERANCE_PERCENT: Final[float] = 0.5
+SLIPPAGE_TOLERANCE_PERCENT: Final[float] = _load_float(
+    "SLIPPAGE_TOLERANCE_PERCENT", 0.5, minimum=0.0, maximum=100.0
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ if str(ROOT_DIR) not in sys.path:
 # Set default environment variables to satisfy config loading
 os.environ.setdefault("RPC_URL", "http://localhost")
 os.environ.setdefault("PRIVATE_KEY", "test")
-os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
 os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
 os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
 os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")

--- a/tests/test_async_functions.py
+++ b/tests/test_async_functions.py
@@ -6,7 +6,7 @@ import pytest
 
 os.environ.setdefault("RPC_URL", "http://localhost")
 os.environ.setdefault("PRIVATE_KEY", "test")
-os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
 os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
 os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
 os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")

--- a/tests/test_custom_exceptions.py
+++ b/tests/test_custom_exceptions.py
@@ -1,7 +1,7 @@
 import os
 os.environ.setdefault("RPC_URL", "http://localhost")
 os.environ.setdefault("PRIVATE_KEY", "key")
-os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
 os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
 os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
 os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -1,7 +1,7 @@
 import os
 os.environ.setdefault("RPC_URL", "http://localhost")
 os.environ.setdefault("PRIVATE_KEY", "key")
-os.environ.setdefault("WALLET_ADDRESS", "addr")
+os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
 os.environ.setdefault("TOKEN0_ADDRESS", "0x0000000000000000000000000000000000000001")
 os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000002")
 os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
@@ -16,7 +16,7 @@ import main
 def test_main_runs(monkeypatch):
     os.environ.setdefault("RPC_URL", "http://localhost")
     os.environ.setdefault("PRIVATE_KEY", "key")
-    os.environ.setdefault("WALLET_ADDRESS", "addr")
+    os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
 
     monkeypatch.setattr(main, "Web3Service", MagicMock())
     monkeypatch.setattr(main, "DEXHandler", MagicMock())


### PR DESCRIPTION
## Summary
- validate Ethereum addresses with Web3
- parse operational parameters from environment with range checks
- update tests to use valid addresses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b39c89d2c8322939d7a12e9671ef9