### PR TITLE
Introduce BaseDEXProtocol with retry and circuit breaker

### DIFF
--- a/dex_protocols/base.py
+++ b/dex_protocols/base.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from exceptions import DexError, ServiceUnavailableError
+from logger import get_logger
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class BaseDEXProtocol(ABC):
+    """Abstract base class for DEX protocol implementations."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger(self.__class__.__name__.lower())
+        self._circuit = CircuitBreaker()
+
+    async def get_quote(self, token_in: str, token_out: str, amount_in: int) -> float:
+        """Return ``token_out`` amount received for ``amount_in`` of ``token_in``."""
+        self._validate_tokens(token_in, token_out)
+        if amount_in <= 0:
+            raise DexError("amount_in must be positive")
+        try:
+            return await self._circuit.call(
+                retry_async, self._get_quote, token_in, token_out, amount_in
+            )
+        except ServiceUnavailableError as exc:
+            self.logger.error("Quote circuit open: %s", exc)
+            return 0.0
+        except DexError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("Quote failed: %s", exc)
+            return 0.0
+
+    async def execute_swap(self, amount_in: int, route: List[str]) -> str:
+        """Execute a swap along ``route`` and return the transaction hash."""
+        if amount_in <= 0 or not route or any(not r for r in route):
+            raise DexError("invalid swap parameters")
+        try:
+            return await self._circuit.call(
+                retry_async, self._execute_swap, amount_in, route
+            )
+        except ServiceUnavailableError as exc:
+            self.logger.error("Swap circuit open: %s", exc)
+            raise DexError("service unavailable") from exc
+        except DexError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Swap failed: %s", exc)
+            raise DexError(str(exc)) from exc
+
+    async def get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> List[str]:
+        """Return the optimal swap route."""
+        self._validate_tokens(token_in, token_out)
+        if amount_in <= 0:
+            raise DexError("amount_in must be positive")
+        try:
+            return await self._circuit.call(
+                retry_async, self._get_best_route, token_in, token_out, amount_in
+            )
+        except ServiceUnavailableError as exc:
+            self.logger.error("Route circuit open: %s", exc)
+            return []
+        except DexError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("Route lookup failed: %s", exc)
+            return []
+
+    def _validate_tokens(self, token_in: str, token_out: str) -> None:
+        if not token_in or not token_out:
+            raise DexError("token addresses required")
+
+    @abstractmethod
+    async def _get_quote(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> float:
+        """Query the protocol for a price quote."""
+
+    @abstractmethod
+    async def _execute_swap(self, amount_in: int, route: List[str]) -> str:
+        """Perform the swap on-chain."""
+
+    @abstractmethod
+    async def _get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> List[str]:
+        """Compute the best swap route."""
+
+
+__all__ = ["BaseDEXProtocol"]

--- a/tests/test_base_dex_protocol.py
+++ b/tests/test_base_dex_protocol.py
@@ -1,0 +1,58 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dex_protocols.base import BaseDEXProtocol
+from exceptions import DexError, ServiceUnavailableError
+
+
+class DummyDEX(BaseDEXProtocol):
+    async def _get_quote(self, token_in: str, token_out: str, amount_in: int) -> float:
+        return 1.23
+
+    async def _execute_swap(self, amount_in: int, route: list[str]) -> str:
+        return "0xdead"
+
+    async def _get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> list[str]:
+        return ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_methods_use_circuit_breaker(monkeypatch):
+    dex = DummyDEX()
+    async def call(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+    call_mock = AsyncMock(side_effect=call)
+    dex._circuit.call = call_mock
+    price = await dex.get_quote("x", "y", 1)
+    tx = await dex.execute_swap(1, ["x", "y"])
+    route = await dex.get_best_route("x", "y", 1)
+    assert price == 1.23
+    assert tx == "0xdead"
+    assert route == ["a", "b"]
+    assert call_mock.await_count == 3
+    assert call_mock.await_args_list[0].args[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_execute_swap_raises_on_service_unavailable(monkeypatch):
+    dex = DummyDEX()
+    async def raise_unavailable(*_a, **_kw):
+        raise ServiceUnavailableError("open")
+    dex._circuit.call = AsyncMock(side_effect=raise_unavailable)
+    with pytest.raises(DexError):
+        await dex.execute_swap(1, ["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_validation_errors():
+    dex = DummyDEX()
+    with pytest.raises(DexError):
+        await dex.get_quote("", "b", 1)
+    with pytest.raises(DexError):
+        await dex.execute_swap(0, [])
+    with pytest.raises(DexError):
+        await dex.get_best_route("a", "", -1)


### PR DESCRIPTION
## Summary
- create `dex_protocols` package with `BaseDEXProtocol`
- implement async quote, swap and route lookup with shared resilience logic
- add unit tests for new base class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b69b359648322ba940fcab551880b