### PR TITLE
Add DEX adapter classes with tests

### DIFF
--- a/dex_protocols/__init__.py
+++ b/dex_protocols/__init__.py
@@ -1,0 +1,12 @@
+from .base import BaseDEXProtocol
+from .uniswap_v3 import UniswapV3
+from .curve import Curve
+from .balancer import Balancer
+
+__all__ = [
+    "BaseDEXProtocol",
+    "UniswapV3",
+    "Curve",
+    "Balancer",
+]
+

--- a/dex_protocols/balancer.py
+++ b/dex_protocols/balancer.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List
+
+from web3.contract import Contract
+
+from dex_protocols.base import BaseDEXProtocol
+from exceptions import DexError
+from web3_service import Web3Service
+
+
+BALANCER_VAULT_ABI: List[Dict[str, Any]] = [
+    {
+        "inputs": [
+            {"internalType": "uint8", "name": "kind", "type": "uint8"},
+            {"internalType": "tuple[]", "name": "swaps", "type": "tuple[]"},
+            {"internalType": "address[]", "name": "assets", "type": "address[]"},
+        ],
+        "name": "queryBatchSwap",
+        "outputs": [
+            {"internalType": "int256[]", "name": "assetDeltas", "type": "int256[]"}
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "tuple", "name": "singleSwap", "type": "tuple"},
+            {"internalType": "tuple", "name": "funds", "type": "tuple"},
+            {"internalType": "uint256", "name": "limit", "type": "uint256"},
+            {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+        ],
+        "name": "swap",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+
+class Balancer(BaseDEXProtocol):
+    """Adapter for Balancer vault swaps."""
+
+    def __init__(
+        self,
+        web3_service: Web3Service,
+        vault_address: str,
+        pool_id: str,
+        gas_limit: int = 250000,
+    ) -> None:
+        super().__init__()
+        self.web3_service = web3_service
+        self.pool_id = pool_id
+        self.gas_limit = gas_limit
+        self.vault: Contract = web3_service.get_contract(
+            vault_address, BALANCER_VAULT_ABI
+        )
+
+    async def _get_quote(self, token_in: str, token_out: str, amount_in: int) -> float:
+        swaps = [
+            {
+                "poolId": self.pool_id,
+                "assetInIndex": 0,
+                "assetOutIndex": 1,
+                "amount": amount_in,
+                "userData": b"",
+            }
+        ]
+        assets = [token_in, token_out]
+        try:
+            func = self.vault.functions.queryBatchSwap(0, swaps, assets).call
+            deltas = await asyncio.to_thread(func)
+            return float(-deltas[1])
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Balancer quote error: %s", exc)
+            raise DexError("quote failed") from exc
+
+    async def _execute_swap(self, amount_in: int, route: List[str]) -> str:
+        token_in, token_out = route[0], route[-1]
+        single_swap = {
+            "poolId": self.pool_id,
+            "kind": 0,
+            "assetIn": token_in,
+            "assetOut": token_out,
+            "amount": amount_in,
+            "userData": b"",
+        }
+        funds = {
+            "sender": self.web3_service.account.address,
+            "recipient": self.web3_service.account.address,
+            "fromInternalBalance": False,
+            "toInternalBalance": False,
+        }
+        try:
+            tx = self.vault.functions.swap(
+                single_swap, funds, 0, int(time.time()) + 300
+            ).build_transaction(
+                {
+                    "from": self.web3_service.account.address,
+                    "gas": self.gas_limit,
+                    "gasPrice": self.web3_service.web3.eth.gas_price,
+                }
+            )
+            receipt = await self.web3_service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Balancer swap error: %s", exc)
+            raise DexError("swap failed") from exc
+
+    async def _get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> List[str]:
+        return [token_in, token_out]
+
+
+__all__ = ["Balancer"]

--- a/dex_protocols/curve.py
+++ b/dex_protocols/curve.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+from web3.contract import Contract
+
+from dex_protocols.base import BaseDEXProtocol
+from exceptions import DexError
+from web3_service import Web3Service
+
+
+CURVE_POOL_ABI: List[Dict[str, Any]] = [
+    {
+        "inputs": [
+            {"name": "i", "type": "int128"},
+            {"name": "j", "type": "int128"},
+            {"name": "dx", "type": "uint256"},
+        ],
+        "name": "get_dy",
+        "outputs": [{"name": "dy", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"name": "i", "type": "int128"},
+            {"name": "j", "type": "int128"},
+            {"name": "dx", "type": "uint256"},
+            {"name": "min_dy", "type": "uint256"},
+        ],
+        "name": "exchange",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+
+class Curve(BaseDEXProtocol):
+    """Adapter for Curve pools."""
+
+    def __init__(
+        self,
+        web3_service: Web3Service,
+        pool_address: str,
+        token_index: Dict[str, int],
+        gas_limit: int = 250000,
+    ) -> None:
+        super().__init__()
+        self.web3_service = web3_service
+        self.pool: Contract = web3_service.get_contract(pool_address, CURVE_POOL_ABI)
+        self.token_index = {k.lower(): v for k, v in token_index.items()}
+        self.gas_limit = gas_limit
+
+    def _idx(self, token: str) -> int:
+        try:
+            return self.token_index[token.lower()]
+        except KeyError as exc:  # noqa: BLE001
+            raise DexError("unknown token") from exc
+
+    async def _get_quote(self, token_in: str, token_out: str, amount_in: int) -> float:
+        try:
+            func = self.pool.functions.get_dy(
+                self._idx(token_in), self._idx(token_out), amount_in
+            ).call
+            amount_out = await asyncio.to_thread(func)
+            return float(amount_out)
+        except DexError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Curve quote error: %s", exc)
+            raise DexError("quote failed") from exc
+
+    async def _execute_swap(self, amount_in: int, route: List[str]) -> str:
+        try:
+            i, j = self._idx(route[0]), self._idx(route[-1])
+            tx = self.pool.functions.exchange(i, j, amount_in, 0).build_transaction(
+                {
+                    "from": self.web3_service.account.address,
+                    "gas": self.gas_limit,
+                    "gasPrice": self.web3_service.web3.eth.gas_price,
+                }
+            )
+            receipt = await self.web3_service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except DexError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Curve swap error: %s", exc)
+            raise DexError("swap failed") from exc
+
+    async def _get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> List[str]:
+        self._idx(token_in)
+        self._idx(token_out)
+        return [token_in, token_out]
+
+
+__all__ = ["Curve"]

--- a/dex_protocols/uniswap_v3.py
+++ b/dex_protocols/uniswap_v3.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List
+
+from web3.contract import Contract
+
+from dex_protocols.base import BaseDEXProtocol
+from exceptions import DexError
+from web3_service import Web3Service
+
+
+UNISWAP_V3_QUOTER_ABI: List[Dict[str, Any]] = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "tokenIn", "type": "address"},
+            {"internalType": "address", "name": "tokenOut", "type": "address"},
+            {"internalType": "uint24", "name": "fee", "type": "uint24"},
+            {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+            {"internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160"},
+        ],
+        "name": "quoteExactInputSingle",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    }
+]
+
+UNISWAP_V3_ROUTER_ABI: List[Dict[str, Any]] = [
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "tokenIn", "type": "address"},
+                    {"internalType": "address", "name": "tokenOut", "type": "address"},
+                    {"internalType": "uint24", "name": "fee", "type": "uint24"},
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                    {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+                    {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+                    {"internalType": "uint256", "name": "amountOutMinimum", "type": "uint256"},
+                    {"internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160"},
+                ],
+                "internalType": "struct ISwapRouter.ExactInputSingleParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "exactInputSingle",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    }
+]
+
+
+class UniswapV3(BaseDEXProtocol):
+    """Adapter for interacting with Uniswap V3."""
+
+    def __init__(
+        self,
+        web3_service: Web3Service,
+        quoter_address: str,
+        router_address: str,
+        fee_tier: int = 3000,
+        gas_limit: int = 250000,
+    ) -> None:
+        super().__init__()
+        self.web3_service = web3_service
+        self.fee_tier = fee_tier
+        self.gas_limit = gas_limit
+        self.quoter: Contract = web3_service.get_contract(
+            quoter_address, UNISWAP_V3_QUOTER_ABI
+        )
+        self.router: Contract = web3_service.get_contract(
+            router_address, UNISWAP_V3_ROUTER_ABI
+        )
+
+    async def _get_quote(self, token_in: str, token_out: str, amount_in: int) -> float:
+        try:
+            func = self.quoter.functions.quoteExactInputSingle(
+                token_in, token_out, self.fee_tier, amount_in, 0
+            ).call
+            amount_out = await asyncio.to_thread(func)
+            return float(amount_out)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("UniswapV3 quote error: %s", exc)
+            raise DexError("quote failed") from exc
+
+    async def _execute_swap(self, amount_in: int, route: List[str]) -> str:
+        token_in, token_out = route[0], route[-1]
+        try:
+            params = {
+                "tokenIn": token_in,
+                "tokenOut": token_out,
+                "fee": self.fee_tier,
+                "recipient": self.web3_service.account.address,
+                "deadline": int(time.time()) + 300,
+                "amountIn": amount_in,
+                "amountOutMinimum": 0,
+                "sqrtPriceLimitX96": 0,
+            }
+            tx = self.router.functions.exactInputSingle(params).build_transaction(
+                {
+                    "from": self.web3_service.account.address,
+                    "gas": self.gas_limit,
+                    "gasPrice": self.web3_service.web3.eth.gas_price,
+                }
+            )
+            receipt = await self.web3_service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("UniswapV3 swap error: %s", exc)
+            raise DexError("swap failed") from exc
+
+    async def _get_best_route(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> List[str]:
+        return [token_in, token_out]
+
+
+__all__ = ["UniswapV3"]

--- a/tests/test_dex_adapters.py
+++ b/tests/test_dex_adapters.py
@@ -1,0 +1,145 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dex_protocols import UniswapV3, Curve, Balancer
+from exceptions import DexError
+from web3_service import TransactionFailedError
+
+
+@pytest.mark.asyncio
+async def test_uniswap_v3_quote_and_swap(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    service.sign_and_send_transaction = AsyncMock(
+        return_value={"transactionHash": b"\x01"}
+    )
+    contract = MagicMock()
+    service.get_contract.return_value = contract
+
+    contract.functions.quoteExactInputSingle.return_value = MagicMock(
+        call=MagicMock(return_value=123)
+    )
+    contract.functions.exactInputSingle.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    dex = UniswapV3(service, "0xquoter", "0xrouter")
+    dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    quote = await dex.get_quote("0xa", "0xb", 1)
+    assert quote == 123
+
+    tx = await dex.execute_swap(1, ["0xa", "0xb"])
+    assert tx == "01"
+    service.sign_and_send_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_uniswap_v3_swap_error(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    contract = MagicMock()
+    service.get_contract.return_value = contract
+
+    contract.functions.quoteExactInputSingle.return_value = MagicMock(
+        call=MagicMock(return_value=123)
+    )
+    contract.functions.exactInputSingle.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+
+    async def fail_tx(_):
+        raise TransactionFailedError("fail")
+
+    service.sign_and_send_transaction = AsyncMock(side_effect=fail_tx)
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    dex = UniswapV3(service, "0xquoter", "0xrouter")
+    dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    with pytest.raises(DexError):
+        await dex.execute_swap(1, ["0xa", "0xb"])
+
+
+@pytest.mark.asyncio
+async def test_curve_quote_and_swap(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    service.sign_and_send_transaction = AsyncMock(
+        return_value={"transactionHash": b"\x02"}
+    )
+    contract = MagicMock()
+    service.get_contract.return_value = contract
+
+    contract.functions.get_dy.return_value = MagicMock(
+        call=MagicMock(return_value=456)
+    )
+    contract.functions.exchange.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    dex = Curve(service, "0xpool", {"0xa": 0, "0xb": 1})
+    dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    quote = await dex.get_quote("0xa", "0xb", 1)
+    assert quote == 456
+
+    tx = await dex.execute_swap(1, ["0xa", "0xb"])
+    assert tx == "02"
+    service.sign_and_send_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_balancer_quote_and_swap(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    service.sign_and_send_transaction = AsyncMock(
+        return_value={"transactionHash": b"\x03"}
+    )
+    contract = MagicMock()
+    service.get_contract.return_value = contract
+
+    contract.functions.queryBatchSwap.return_value = MagicMock(
+        call=MagicMock(return_value=[0, -789])
+    )
+    contract.functions.swap.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    dex = Balancer(service, "0xvault", "0xpool")
+    dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    quote = await dex.get_quote("0xa", "0xb", 1)
+    assert quote == 789
+
+    tx = await dex.execute_swap(1, ["0xa", "0xb"])
+    assert tx == "03"
+    service.sign_and_send_transaction.assert_awaited_once()
+
+
+


### PR DESCRIPTION
## Summary
- implement `UniswapV3`, `Curve`, and `Balancer` adapter classes
- expose adapters via `dex_protocols/__init__`
- add unit tests for quoting and swapping using mocked contracts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6c0fd5948322bd0056ccfbf09df2