### PR TITLE
Implement multi-hop routing with caching

### DIFF
--- a/routing/router.py
+++ b/routing/router.py
@@ -1,56 +1,131 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Tuple
+import heapq
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
 
 from dex_protocols.base import BaseDEXProtocol
 from exceptions import DexError
 from logger import get_logger
 
+
+@dataclass
+class _Edge:
+    """Graph edge representing a swap option."""
+
+    token_out: str
+    protocol: BaseDEXProtocol
+    cost: float
+
 logger = get_logger("router")
 
 
 class Router:
-    """Aggregate multiple DEX protocol adapters."""
+    """Aggregate multiple DEX protocol adapters with multi-hop logic."""
 
-    def __init__(self, protocols: Iterable[BaseDEXProtocol]):
+    def __init__(self, protocols: Iterable[BaseDEXProtocol], ttl: int = 30) -> None:
         self.protocols: List[BaseDEXProtocol] = list(protocols)
+        self._graph: Dict[str, List[_Edge]] = {}
+        self._cache: Dict[Tuple[str, str, int], Tuple[List[BaseDEXProtocol], List[str], float]] = {}
+        self._ttl = ttl
+        self._build_graph()
 
     def add_protocol(self, protocol: BaseDEXProtocol) -> None:
         """Register a new protocol adapter."""
         self.protocols.append(protocol)
 
+    def _current_block(self) -> int:
+        try:
+            return self.protocols[0].web3_service.web3.eth.block_number
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def _shortest_path(
+        self, token_in: str, token_out: str
+    ) -> Tuple[List[BaseDEXProtocol], List[str]]:
+        dist: Dict[str, float] = {token_in: 0.0}
+        prev: Dict[str, Tuple[str, BaseDEXProtocol]] = {}
+        queue: List[Tuple[float, str]] = [(0.0, token_in)]
+        while queue:
+            cost, token = heapq.heappop(queue)
+            if token == token_out:
+                break
+            for edge in self._graph.get(token, []):
+                new_cost = cost + edge.cost
+                if new_cost < dist.get(edge.token_out, float("inf")):
+                    dist[edge.token_out] = new_cost
+                    prev[edge.token_out] = (token, edge.protocol)
+                    heapq.heappush(queue, (new_cost, edge.token_out))
+        if token_out not in prev:
+            raise DexError("no route")
+        tokens: List[str] = [token_out]
+        protocols: List[BaseDEXProtocol] = []
+        curr = token_out
+        while curr != token_in:
+            prev_token, proto = prev[curr]
+            tokens.append(prev_token)
+            protocols.append(proto)
+            curr = prev_token
+        tokens.reverse()
+        protocols.reverse()
+        return protocols, tokens
+
+    def _build_graph(self) -> None:
+        """Construct the token graph from protocol pool data."""
+        for proto in self.protocols:
+            pools = getattr(proto, "pools", [])
+            try:
+                gas_price = proto.web3_service.web3.eth.gas_price
+            except Exception:  # noqa: BLE001
+                gas_price = 0.0
+            gas_cost = gas_price * getattr(proto, "gas_limit", 0)
+            for token_a, token_b, fee in pools:
+                cost = float(fee) + float(gas_cost)
+                self._graph.setdefault(token_a, []).append(
+                    _Edge(token_b, proto, cost)
+                )
+                self._graph.setdefault(token_b, []).append(
+                    _Edge(token_a, proto, cost)
+                )
+
     async def get_best_route(
         self, token_in: str, token_out: str, amount_in: int
-    ) -> Tuple[BaseDEXProtocol, List[str]]:
-        """Return adapter and route with the highest quoted amount."""
-        best: Tuple[BaseDEXProtocol, List[str], float] | None = None
-        for proto in self.protocols:
-            try:
-                route = await proto.get_best_route(token_in, token_out, amount_in)
-                if not route:
-                    continue
-                quote = await proto.get_quote(token_in, token_out, amount_in)
-                if quote > 0 and (best is None or quote > best[2]):
-                    best = (proto, route, quote)
-            except DexError:
-                continue
-        if best is None:
-            raise DexError("no liquidity available")
-        return best[0], best[1]
+    ) -> Tuple[List[BaseDEXProtocol], List[str]]:
+        """Return protocols and route with the lowest total cost."""
+        if amount_in <= 0 or not token_in or not token_out:
+            raise DexError("invalid parameters")
+        block = self._current_block()
+        key = (token_in, token_out, block)
+        cached = self._cache.get(key)
+        if cached and cached[2] > time.time():
+            return cached[0], cached[1]
+        protocols, route = self._shortest_path(token_in, token_out)
+        self._cache[key] = (protocols, route, time.time() + self._ttl)
+        return protocols, route
 
     async def get_best_quote(
         self, token_in: str, token_out: str, amount_in: int
     ) -> float:
-        """Return the highest output amount for the swap."""
-        proto, _ = await self.get_best_route(token_in, token_out, amount_in)
-        return await proto.get_quote(token_in, token_out, amount_in)
+        """Return the estimated output amount for the optimal path."""
+        protocols, route = await self.get_best_route(token_in, token_out, amount_in)
+        amt = float(amount_in)
+        for idx, proto in enumerate(protocols):
+            amt = await proto.get_quote(route[idx], route[idx + 1], int(amt))
+        return amt
 
     async def execute_swap(
         self, amount_in: int, token_in: str, token_out: str
     ) -> str:
-        """Execute swap on the best protocol for the pair."""
-        proto, route = await self.get_best_route(token_in, token_out, amount_in)
-        logger.info(
-            "Executing swap via %s: %s", proto.__class__.__name__, " -> ".join(route)
-        )
-        return await proto.execute_swap(amount_in, route)
+        """Execute sequential swaps along the optimal path."""
+        protocols, route = await self.get_best_route(token_in, token_out, amount_in)
+        amt = amount_in
+        tx = ""
+        for idx, proto in enumerate(protocols):
+            hop = [route[idx], route[idx + 1]]
+            logger.info(
+                "Executing hop via %s: %s", proto.__class__.__name__, " -> ".join(hop)
+            )
+            tx = await proto.execute_swap(amt, hop)
+            amt = await proto.get_quote(hop[0], hop[1], amt)
+        return tx

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -7,37 +7,59 @@ from routing import Router
 
 
 class DummyProto:
-    def __init__(self, quote: float, name: str = "proto"):
-        self.quote = quote
+    def __init__(self, pools, name: str):
+        self.pools = pools
         self.name = name
-        self.get_best_route = AsyncMock(return_value=["a", "b"])
-        self.get_quote = AsyncMock(return_value=quote)
+        self.get_quote = AsyncMock(return_value=1.0)
         self.execute_swap = AsyncMock(return_value=f"tx-{name}")
+        service = MagicMock()
+        service.web3.eth.gas_price = 1
+        self.web3_service = service
+        self.gas_limit = 1
 
 
 @pytest.mark.asyncio
-async def test_get_best_route_selects_highest_quote():
-    p1 = DummyProto(1.0, "p1")
-    p2 = DummyProto(2.0, "p2")
+async def test_multi_hop_route_selection():
+    p1 = DummyProto([("a", "b", 1)], "p1")
+    p2 = DummyProto([("b", "c", 1)], "p2")
+    p3 = DummyProto([("a", "c", 5)], "p3")
+    router = Router([p1, p2, p3])
+
+    protos, route = await router.get_best_route("a", "c", 1)
+    assert route == ["a", "b", "c"]
+    assert protos == [p1, p2]
+
+
+@pytest.mark.asyncio
+async def test_execute_swap_delegates_to_adapters():
+    p1 = DummyProto([("a", "b", 1)], "p1")
+    p2 = DummyProto([("b", "c", 1)], "p2")
     router = Router([p1, p2])
-
-    proto, route = await router.get_best_route("a", "b", 1)
-    assert proto is p2
-    assert route == ["a", "b"]
-
-
-@pytest.mark.asyncio
-async def test_execute_swap_delegates_to_adapter():
-    p1 = DummyProto(1.0, "p1")
-    router = Router([p1])
-    tx = await router.execute_swap(1, "a", "b")
-    assert tx == "tx-p1"
-    p1.execute_swap.assert_awaited_once()
+    tx = await router.execute_swap(1, "a", "c")
+    assert tx == "tx-p2"
+    assert p1.execute_swap.await_count == 1
+    assert p2.execute_swap.await_count == 1
 
 
 @pytest.mark.asyncio
 async def test_no_liquidity_raises_error():
-    p1 = DummyProto(0.0)
+    p1 = DummyProto([], "p1")
     router = Router([p1])
     with pytest.raises(DexError):
         await router.get_best_route("a", "b", 1)
+
+
+@pytest.mark.asyncio
+async def test_route_cache(monkeypatch):
+    p1 = DummyProto([("a", "b", 1)], "p1")
+    router = Router([p1])
+    monkeypatch.setattr(router, "_current_block", lambda: 1)
+    path_mock = MagicMock(return_value=([p1], ["a", "b"]))
+    router._shortest_path = path_mock
+    await router.get_best_route("a", "b", 1)
+    await router.get_best_route("a", "b", 1)
+    assert path_mock.call_count == 1
+    monkeypatch.setattr(router, "_current_block", lambda: 2)
+    await router.get_best_route("a", "b", 1)
+    assert path_mock.call_count == 2
+


### PR DESCRIPTION
## Summary
- add `_Edge` dataclass and build graph of token pairs
- compute shortest path across protocols using Dijkstra
- cache results per block number
- execute multi-hop swaps sequentially
- update router tests for multihop logic and caching

## Testing
- `pytest tests/test_router.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6f94c2a083228b300cbe2fd1cc5c