### PR TITLE
Add token detection and balance checks

### DIFF
--- a/dex_protocols/balancer.py
+++ b/dex_protocols/balancer.py
@@ -8,6 +8,14 @@ from web3.contract import Contract
 
 from dex_protocols.base import BaseDEXProtocol
 from exceptions import DexError
+from tokens.detect import (
+    ERC20_ABI,
+    TokenInspectionError,
+    TokenType,
+    detect_token_type,
+    gas_multiplier,
+    get_token_balance,
+)
 from web3_service import Web3Service
 
 
@@ -96,16 +104,31 @@ class Balancer(BaseDEXProtocol):
             "toInternalBalance": False,
         }
         try:
+            contract = self.web3_service.get_contract(token_out, ERC20_ABI)
+            try:
+                token_type = await detect_token_type(contract)
+            except TokenInspectionError:
+                token_type = TokenType.ERC20
+            multiplier = gas_multiplier(token_type)
+            balance_before = await get_token_balance(
+                contract, self.web3_service.account.address
+            )
+
             tx = self.vault.functions.swap(
                 single_swap, funds, 0, int(time.time()) + 300
             ).build_transaction(
                 {
                     "from": self.web3_service.account.address,
-                    "gas": self.gas_limit,
+                    "gas": int(self.gas_limit * multiplier),
                     "gasPrice": self.web3_service.web3.eth.gas_price,
                 }
             )
             receipt = await self.web3_service.sign_and_send_transaction(tx)
+            balance_after = await get_token_balance(
+                contract, self.web3_service.account.address
+            )
+            if balance_after <= balance_before:
+                raise DexError("token balance check failed")
             return receipt["transactionHash"].hex()
         except Exception as exc:  # noqa: BLE001
             self.logger.error("Balancer swap error: %s", exc)

--- a/tests/test_balance_validation.py
+++ b/tests/test_balance_validation.py
@@ -1,0 +1,29 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dex_handler import DEXHandler
+from exceptions import DexError
+from tokens import detect
+
+
+@pytest.mark.asyncio
+async def test_balance_check_failure(monkeypatch):
+    handler = DEXHandler.__new__(DEXHandler)
+    handler.web3_service = MagicMock()
+    handler.contract = MagicMock()
+    handler.web3_service.account = MagicMock(address="0xabc")
+    handler.web3_service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    handler._circuit = MagicMock(call=lambda f, *a, **kw: f(*a, **kw))
+
+    swap_func = MagicMock(return_value=MagicMock(build_transaction=MagicMock(return_value={"tx": 1})))
+    handler.contract.functions.swapExactETHForTokens = swap_func
+    handler.web3_service.sign_and_send_transaction = AsyncMock(return_value={"transactionHash": b"\x01"})
+    handler.web3_service.get_contract.return_value = MagicMock()
+
+    monkeypatch.setattr(detect, "detect_token_type", AsyncMock(return_value=detect.TokenType.ERC20))
+    monkeypatch.setattr(detect, "get_token_balance", AsyncMock(side_effect=[0, 0]))
+
+    with pytest.raises(DexError):
+        await handler.execute_swap(1, ["a", "b"])

--- a/tests/test_dex_adapters.py
+++ b/tests/test_dex_adapters.py
@@ -3,8 +3,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dex_protocols import UniswapV3, Curve, Balancer
+import dex_protocols
+from dex_protocols import Balancer, Curve, UniswapV3
 from exceptions import DexError
+from tokens import detect
+from utils import retry
 from web3_service import TransactionFailedError
 
 
@@ -30,7 +33,13 @@ async def test_uniswap_v3_quote_and_swap(monkeypatch):
         return func()
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(retry, "retry_async", lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(retry, "retry_async", lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(retry, "retry_async", lambda func, *a, **kw: func(*a, **kw))
+    monkeypatch.setattr(retry, "retry_async", lambda func, *a, **kw: func(*a, **kw))
 
+    monkeypatch.setattr(dex_protocols.uniswap_v3, "detect_token_type", AsyncMock(return_value=detect.TokenType.ERC20))
+    monkeypatch.setattr(dex_protocols.uniswap_v3, "get_token_balance", AsyncMock(side_effect=[0, 1]))
     dex = UniswapV3(service, "0xquoter", "0xrouter")
     dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
 
@@ -67,6 +76,8 @@ async def test_uniswap_v3_swap_error(monkeypatch):
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
+    monkeypatch.setattr(dex_protocols.uniswap_v3, "detect_token_type", AsyncMock(return_value=detect.TokenType.ERC20))
+    monkeypatch.setattr(dex_protocols.uniswap_v3, "get_token_balance", AsyncMock(side_effect=[0, 1]))
     dex = UniswapV3(service, "0xquoter", "0xrouter")
     dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
 
@@ -97,6 +108,8 @@ async def test_curve_quote_and_swap(monkeypatch):
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
+    monkeypatch.setattr(dex_protocols.curve, "detect_token_type", AsyncMock(return_value=detect.TokenType.ERC20))
+    monkeypatch.setattr(dex_protocols.curve, "get_token_balance", AsyncMock(side_effect=[0, 1]))
     dex = Curve(service, "0xpool", {"0xa": 0, "0xb": 1})
     dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
 
@@ -131,6 +144,8 @@ async def test_balancer_quote_and_swap(monkeypatch):
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
+    monkeypatch.setattr(dex_protocols.balancer, "detect_token_type", AsyncMock(return_value=detect.TokenType.ERC20))
+    monkeypatch.setattr(dex_protocols.balancer, "get_token_balance", AsyncMock(side_effect=[0, 1]))
     dex = Balancer(service, "0xvault", "0xpool")
     dex._circuit.call = lambda func, *a, **kw: func(*a, **kw)
 

--- a/tests/test_token_detection.py
+++ b/tests/test_token_detection.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import MagicMock
+
+from tokens import detect
+
+
+class MockContract:
+    def __init__(self, funcs):
+        self._funcs = funcs
+
+    def get_function_by_name(self, name):
+        if name in self._funcs:
+            return object()
+        raise ValueError()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "funcs,expected",
+    [
+        ({"granularity"}, detect.TokenType.ERC777),
+        ({"rebase"}, detect.TokenType.REBASING),
+        ({"fee"}, detect.TokenType.FEE_ON_TRANSFER),
+        (set(), detect.TokenType.ERC20),
+    ],
+)
+async def test_detect_token_type(funcs, expected):
+    contract = MockContract(funcs)
+    assert await detect.detect_token_type(contract) is expected

--- a/tokens/detect.py
+++ b/tokens/detect.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+from enum import Enum
+from typing import Any, Dict, List
+
+from web3.contract import Contract
+
+from logger import get_logger
+
+logger = get_logger("token_detect")
+
+
+class TokenInspectionError(Exception):
+    """Raised when token inspection fails."""
+
+
+class TokenType(Enum):
+    ERC20 = "erc20"
+    ERC777 = "erc777"
+    FEE_ON_TRANSFER = "fee_on_transfer"
+    REBASING = "rebasing"
+
+
+ERC20_ABI: List[Dict[str, Any]] = [
+    {
+        "name": "balanceOf",
+        "inputs": [{"name": "account", "type": "address"}],
+        "outputs": [{"name": "balance", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+_GAS_MULTIPLIER = {
+    TokenType.ERC20: 1.0,
+    TokenType.ERC777: 1.1,
+    TokenType.FEE_ON_TRANSFER: 1.2,
+    TokenType.REBASING: 1.3,
+}
+
+
+def gas_multiplier(token_type: TokenType) -> float:
+    """Return gas multiplier for ``token_type``."""
+    return _GAS_MULTIPLIER.get(token_type, 1.0)
+
+
+def _has_function(contract: Contract, name: str) -> bool:
+    try:
+        contract.get_function_by_name(name)
+        return True
+    except ValueError:
+        return False
+
+
+async def detect_token_type(contract: Contract) -> TokenType:
+    """Inspect ``contract`` and return its token type."""
+    if contract is None:
+        raise TokenInspectionError("contract required")
+    try:
+        if _has_function(contract, "granularity"):
+            return TokenType.ERC777
+        if _has_function(contract, "rebase"):
+            return TokenType.REBASING
+        if _has_function(contract, "fee") or _has_function(contract, "fees"):
+            return TokenType.FEE_ON_TRANSFER
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Detection failed: %s", exc)
+    return TokenType.ERC20
+
+
+async def get_token_balance(contract: Contract, address: str) -> int:
+    """Return token balance for ``address``."""
+    if contract is None or not address:
+        raise TokenInspectionError("invalid arguments")
+    try:
+        func = contract.functions.balanceOf(address).call
+        result = await asyncio.to_thread(func)
+        return int(result)
+    except Exception as exc:  # noqa: BLE001
+        raise TokenInspectionError(str(exc)) from exc
+
+
+__all__ = [
+    "TokenType",
+    "detect_token_type",
+    "get_token_balance",
+    "ERC20_ABI",
+    "gas_multiplier",
+]


### PR DESCRIPTION
## Summary
- add utility to detect token types and helpers for balance
- adjust DEX handlers and protocol swaps to adapt gas limits and validate balances
- test detection logic and swap balance validation
- update adapter tests with mocked token behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b72d3c76083229ea2f05f694b7754