### PR TITLE
Add multicall batcher with tests

### DIFF
--- a/batcher.py
+++ b/batcher.py
@@ -1,0 +1,79 @@
+"""Batch multiple swap operations into a single multicall."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from web3.contract import Contract
+from web3.exceptions import ContractLogicError
+
+import config
+from exceptions import BatcherError, DexError, ServiceUnavailableError
+from logger import get_logger
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+from web3_service import (
+    TransactionFailedError,
+    TransactionTimeoutError,
+    Web3Service,
+)
+
+MULTICALL_ABI: List[Dict[str, Any]] = [
+    {
+        "inputs": [
+            {"internalType": "bytes[]", "name": "data", "type": "bytes[]"}
+        ],
+        "name": "multicall",
+        "outputs": [
+            {"internalType": "bytes[]", "name": "results", "type": "bytes[]"}
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    }
+]
+
+logger = get_logger("batcher")
+
+
+class Batcher:
+    """Assemble and execute batched swaps atomically."""
+
+    def __init__(self, web3_service: Web3Service, address: str) -> None:
+        self.web3_service = web3_service
+        self.contract: Contract = web3_service.get_contract(
+            address, MULTICALL_ABI
+        )
+        self.base_gas_limit = config.GAS_LIMIT
+        self._circuit = CircuitBreaker()
+
+    async def execute(self, calls: List[bytes], reorder: bool = False) -> str:
+        """Execute all calls in a single transaction."""
+        if not calls:
+            raise DexError("no calls provided")
+        data = sorted(calls, key=len) if reorder else calls
+        gas_limit = max(self.base_gas_limit, self.base_gas_limit * len(data))
+        tx = self.contract.functions.multicall(data).build_transaction(
+            {
+                "from": self.web3_service.account.address,
+                "gas": gas_limit,
+                "gasPrice": self.web3_service.web3.eth.gas_price,
+            }
+        )
+        try:
+            receipt = await self._circuit.call(
+                retry_async, self.web3_service.sign_and_send_transaction, tx
+            )
+            return receipt["transactionHash"].hex()
+        except ServiceUnavailableError as exc:
+            logger.error("Batch circuit open: %s", exc)
+            raise BatcherError("service unavailable") from exc
+        except (
+            TransactionFailedError,
+            TransactionTimeoutError,
+            ContractLogicError,
+        ) as exc:
+            logger.error("Batch execution failed: %s", exc)
+            raise BatcherError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Batch execution error: %s", exc)
+            raise BatcherError(str(exc)) from exc

--- a/exceptions.py
+++ b/exceptions.py
@@ -28,6 +28,13 @@ class DexError(BaseAppError):
         super().__init__("dex_error", message)
 
 
+class BatcherError(BaseAppError):
+    """Raised for errors during batched transactions."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("batcher_error", message)
+
+
 class StrategyError(BaseAppError):
     """Raised for errors in strategy execution or setup."""
 

--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -1,0 +1,55 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from batcher import Batcher
+from exceptions import BatcherError, DexError
+
+
+@pytest.mark.asyncio
+async def test_batcher_execute_success(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    multicall = MagicMock()
+    multicall.functions.multicall.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+    service.get_contract.return_value = multicall
+    service.sign_and_send_transaction = AsyncMock(
+        return_value={"transactionHash": b"\x01"}
+    )
+    batcher = Batcher(service, "0xbatch")
+    batcher._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    tx = await batcher.execute([b"a", b"b"], reorder=True)
+    assert tx == "01"
+    service.sign_and_send_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_batcher_execute_failure(monkeypatch):
+    service = MagicMock()
+    service.account = MagicMock(address="0xabc")
+    service.web3 = MagicMock(eth=MagicMock(gas_price=1))
+    multicall = MagicMock()
+    multicall.functions.multicall.return_value = MagicMock(
+        build_transaction=MagicMock(return_value={"tx": 1})
+    )
+    service.get_contract.return_value = multicall
+    service.sign_and_send_transaction = AsyncMock(
+        side_effect=Exception("fail")
+    )
+    batcher = Batcher(service, "0xbatch")
+    batcher._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+
+    with pytest.raises(BatcherError):
+        await batcher.execute([b"a"])
+
+
+@pytest.mark.asyncio
+async def test_batcher_validate_calls(monkeypatch):
+    batcher = Batcher.__new__(Batcher)
+    with pytest.raises(DexError):
+        await Batcher.execute(batcher, [])


### PR DESCRIPTION
## Summary
- create `batcher` module for grouping swaps into a single multicall
- raise new `BatcherError` on failures
- test successful and failing batcher operations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b750bba608322a168dbc76b74e282