### PR TITLE
Add slippage protection module

### DIFF
--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -6,5 +6,15 @@ TRADE_COUNT = Counter('trade_count_total', 'Number of trades executed')
 TRADE_SUCCESS = Counter('trade_success_total', 'Number of successful trades')
 TRADE_PNL = Counter('trade_pnl_total', 'Total realized P&L')
 API_LATENCY = Histogram('api_latency_seconds', 'Latency of API calls')
-
-__all__ = ['TRADE_COUNT', 'TRADE_SUCCESS', 'TRADE_PNL', 'API_LATENCY']
+SLIPPAGE_CHECKS = Counter('slippage_checks_total', 'Number of slippage checks')
+SLIPPAGE_REJECTED = Counter(
+    'slippage_rejected_total', 'Trades rejected due to slippage'
+)
+__all__ = [
+    'TRADE_COUNT',
+    'TRADE_SUCCESS',
+    'TRADE_PNL',
+    'API_LATENCY',
+    'SLIPPAGE_CHECKS',
+    'SLIPPAGE_REJECTED',
+]

--- a/slippage_protection.py
+++ b/slippage_protection.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from exceptions import PriceManipulationError, ServiceUnavailableError
+from logger import get_logger
+from observability.metrics import SLIPPAGE_CHECKS, SLIPPAGE_REJECTED
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+logger = get_logger("slippage_protection")
+
+
+@dataclass
+class MarketConditions:
+    """Current market data for slippage checks."""
+
+    price: float
+    liquidity: float
+    volatility: float
+
+
+@dataclass
+class SlippageParams:
+    """Parameters controlling slippage protection."""
+
+    tolerance_percent: float
+    data_api: Optional[str] = None
+
+
+class SlippageProtectionEngine:
+    """Check slippage tolerance using external market data."""
+
+    def __init__(self, params: SlippageParams) -> None:
+        self.params = params
+        self._circuit = CircuitBreaker()
+
+    async def _fetch_market_data(self) -> MarketConditions:
+        if not self.params.data_api:
+            raise ServiceUnavailableError("market data endpoint not configured")
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(self.params.data_api)
+            response.raise_for_status()
+            data = response.json()
+        return MarketConditions(
+            price=float(data["price"]),
+            liquidity=float(data.get("liquidity", 0)),
+            volatility=float(data.get("volatility", 0)),
+        )
+
+    async def get_market_conditions(self) -> MarketConditions:
+        try:
+            return await self._circuit.call(retry_async, self._fetch_market_data)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Market data fetch failed: %s", exc)
+            raise
+
+    async def check(self, expected_price: float, amount: float) -> None:
+        if expected_price <= 0 or amount < 0:
+            raise ValueError("invalid expected_price or amount")
+        SLIPPAGE_CHECKS.inc()
+        market = await self.get_market_conditions()
+        slippage = abs(market.price - expected_price) / expected_price * 100
+        if slippage > self.params.tolerance_percent:
+            SLIPPAGE_REJECTED.inc()
+            raise PriceManipulationError(
+                f"Slippage {slippage:.2f}% exceeds tolerance"
+            )
+        if amount > market.liquidity:
+            logger.warning(
+                "Trade amount %.4f exceeds liquidity %.4f",
+                amount,
+                market.liquidity,
+            )
+        logger.info(
+            "Slippage %.2f%% within tolerance %.2f%%",
+            slippage,
+            self.params.tolerance_percent,
+        )
+
+
+__all__ = [
+    "MarketConditions",
+    "SlippageParams",
+    "SlippageProtectionEngine",
+]

--- a/tests/test_slippage_protection.py
+++ b/tests/test_slippage_protection.py
@@ -1,0 +1,66 @@
+import pytest
+
+import slippage_protection
+
+from exceptions import PriceManipulationError
+from slippage_protection import (
+    MarketConditions,
+    SlippageParams,
+    SlippageProtectionEngine,
+)
+from observability.metrics import SLIPPAGE_CHECKS, SLIPPAGE_REJECTED
+
+
+@pytest.mark.asyncio
+async def test_check_within_tolerance(monkeypatch):
+    params = SlippageParams(tolerance_percent=2.0, data_api="http://test")
+    engine = SlippageProtectionEngine(params)
+
+    async def fake_fetch() -> MarketConditions:
+        return MarketConditions(price=100.0, liquidity=50.0, volatility=0.1)
+
+    monkeypatch.setattr(engine, "_fetch_market_data", fake_fetch)
+    start = SLIPPAGE_CHECKS._value.get()
+    await engine.check(101.0, 10)
+    assert SLIPPAGE_CHECKS._value.get() == start + 1
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_on_slippage(monkeypatch):
+    params = SlippageParams(tolerance_percent=1.0, data_api="http://test")
+    engine = SlippageProtectionEngine(params)
+
+    async def fake_fetch() -> MarketConditions:
+        return MarketConditions(price=110.0, liquidity=100.0, volatility=0.1)
+
+    monkeypatch.setattr(engine, "_fetch_market_data", fake_fetch)
+    start = SLIPPAGE_REJECTED._value.get()
+    with pytest.raises(PriceManipulationError):
+        await engine.check(100.0, 10)
+    assert SLIPPAGE_REJECTED._value.get() == start + 1
+
+
+@pytest.mark.asyncio
+async def test_check_warns_on_liquidity(monkeypatch):
+    params = SlippageParams(tolerance_percent=5.0, data_api="http://test")
+    engine = SlippageProtectionEngine(params)
+    warnings: list[str] = []
+
+    async def fake_fetch() -> MarketConditions:
+        return MarketConditions(price=100.0, liquidity=5.0, volatility=0.1)
+
+    monkeypatch.setattr(engine, "_fetch_market_data", fake_fetch)
+    monkeypatch.setattr(
+        slippage_protection,
+        "logger",
+        type(
+            "L",
+            (),
+            {
+                "warning": lambda msg, *a, **k: warnings.append(msg),
+                "info": lambda *a, **k: None,
+            },
+        ),
+    )
+    await engine.check(100.0, 10)
+    assert warnings


### PR DESCRIPTION
## Summary
- implement slippage protection engine
- expose slippage metrics
- test slippage protection logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b79de767c8322a725b16e6d5b9c47