### PR TITLE
Add tests for slippage analysis and update router

### DIFF
--- a/tests/test_slippage_protection.py
+++ b/tests/test_slippage_protection.py
@@ -7,6 +7,7 @@ from slippage_protection import (
     MarketConditions,
     SlippageParams,
     SlippageProtectionEngine,
+    calculate_dynamic_slippage,
 )
 from observability.metrics import SLIPPAGE_CHECKS, SLIPPAGE_REJECTED
 
@@ -64,3 +65,22 @@ async def test_check_warns_on_liquidity(monkeypatch):
     )
     await engine.check(100.0, 10)
     assert warnings
+
+
+def test_analyze_market_conditions_classification():
+    engine = SlippageProtectionEngine(SlippageParams(1.0, None))
+    assert (
+        engine.analyze_market_conditions(MarketConditions(100.0, 100.0, 0.6))
+        == "volatile"
+    )
+    assert (
+        engine.analyze_market_conditions(MarketConditions(100.0, 5.0, 0.1))
+        == "illiquid"
+    )
+    assert (
+        engine.analyze_market_conditions(MarketConditions(100.0, 50.0, 0.1)) == "stable"
+    )
+
+
+def test_calculate_dynamic_slippage():
+    assert calculate_dynamic_slippage(0.1, 0.2) == 0.1 * 1.2


### PR DESCRIPTION
## Summary
- add `analyze_market_conditions` and `calculate_dynamic_slippage` helpers
- integrate slippage analysis into router dynamic slippage calculation
- test new helpers and router interactions

## Testing
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7ea9f24c8322b4163107720f8c02