### PR TITLE
Add arbitrage engine with flash-loan and cross-chain modules

### DIFF
--- a/cross_chain/__init__.py
+++ b/cross_chain/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Cross-chain bridge interfaces."""
+
+from abc import ABC, abstractmethod
+
+from web3_service import Web3Service
+
+
+class BridgeError(Exception):
+    """Raised when bridging fails."""
+
+
+class Bridge(ABC):
+    """Abstract bridge base class."""
+
+    def __init__(self, service: Web3Service) -> None:
+        self.service = service
+
+    @abstractmethod
+    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
+        """Bridge ``token`` to ``dst_chain``."""
+
+
+class LayerZeroBridge(Bridge):
+    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
+        try:
+            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
+        except Exception as exc:  # noqa: BLE001
+            raise BridgeError(str(exc)) from exc
+
+
+class CCIPBridge(Bridge):
+    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
+        try:
+            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
+        except Exception as exc:  # noqa: BLE001
+            raise BridgeError(str(exc)) from exc
+
+
+class WormholeBridge(Bridge):
+    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
+        try:
+            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
+        except Exception as exc:  # noqa: BLE001
+            raise BridgeError(str(exc)) from exc
+
+
+__all__ = ["Bridge", "LayerZeroBridge", "CCIPBridge", "WormholeBridge", "BridgeError"]

--- a/exceptions.py
+++ b/exceptions.py
@@ -42,6 +42,13 @@ class StrategyError(BaseAppError):
         super().__init__("strategy_error", message)
 
 
+class InventoryError(BaseAppError):
+    """Raised for inventory management issues."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("inventory_error", message)
+
+
 class RateLimitError(BaseAppError):
     """Raised when a client exceeds allowed request rate."""
 

--- a/flash_loans/__init__.py
+++ b/flash_loans/__init__.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Flash loan utilities."""
+
+from abc import ABC, abstractmethod
+from typing import Awaitable, Callable
+
+from web3_service import Web3Service
+
+
+class FlashLoanError(Exception):
+    """Raised when flash loan execution fails."""
+
+
+class FlashLoanProvider(ABC):
+    """Abstract flash loan provider interface."""
+
+    def __init__(self, service: Web3Service) -> None:
+        self.service = service
+
+    @abstractmethod
+    async def borrow(self, token: str, amount: int) -> str:
+        """Borrow ``amount`` of ``token`` and return tx hash."""
+
+    @abstractmethod
+    async def repay(self, token: str, amount: int) -> str:
+        """Repay ``amount`` of ``token`` and return tx hash."""
+
+
+class FlashLoanExecutor:
+    """Coordinate flash loan borrow, trade, and repay steps."""
+
+    def __init__(self, provider: FlashLoanProvider) -> None:
+        self.provider = provider
+
+    async def execute(
+        self,
+        token: str,
+        amount: int,
+        trade_fn: Callable[[], Awaitable[str]],
+    ) -> str:
+        await self.provider.borrow(token, amount)
+        try:
+            tx = await trade_fn()
+        except Exception as exc:  # noqa: BLE001
+            await self.provider.repay(token, amount)
+            raise FlashLoanError(str(exc)) from exc
+        await self.provider.repay(token, amount)
+        return tx
+
+
+__all__ = ["FlashLoanProvider", "FlashLoanExecutor", "FlashLoanError"]

--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Profit optimization utilities."""
+
+from typing import List
+
+
+class ProfitOptimizer:
+    """Naive linear optimization for position sizing."""
+
+    def __init__(self, max_capital: float) -> None:
+        if max_capital <= 0:
+            raise ValueError("max_capital must be positive")
+        self.max_capital = max_capital
+
+    def optimize(self, expected_profits: List[float]) -> List[float]:
+        """Allocate capital to the most profitable opportunity."""
+        if not expected_profits:
+            return []
+        idx = max(range(len(expected_profits)), key=lambda i: expected_profits[i])
+        allocation = [0.0 for _ in expected_profits]
+        allocation[idx] = self.max_capital
+        return allocation
+
+
+__all__ = ["ProfitOptimizer"]

--- a/strategies/arbitrage.py
+++ b/strategies/arbitrage.py
@@ -8,6 +8,7 @@ import config
 from routing import Router
 from risk_manager import RiskManager
 from strategies.base import BaseStrategy, StrategyConfig
+from strategies.arbitrage_engine import ArbitrageEngine, ArbitrageType
 
 
 class ArbitrageStrategy(BaseStrategy):
@@ -18,11 +19,15 @@ class ArbitrageStrategy(BaseStrategy):
         router: Router,
         strategy_config: StrategyConfig | None = None,
         risk_manager: RiskManager | None = None,
+        use_engine: bool | None = None,
     ) -> None:
         cfg = strategy_config or StrategyConfig(name="arbitrage")
         super().__init__(router, cfg, risk_manager)
         self.token0 = config.TOKEN0_ADDRESS
         self.token1 = config.TOKEN1_ADDRESS
+        self.engine = None
+        if use_engine:
+            self.engine = ArbitrageEngine(router, cfg, self.risk_manager, [self.token0, self.token1])
 
     def _check_profitability(self, start: float, end: float) -> List[Dict[str, Any]]:
         profit_margin = end - start
@@ -41,15 +46,21 @@ class ArbitrageStrategy(BaseStrategy):
         return []
 
     async def analyze_market(self) -> Dict[str, Any]:
+        if self.engine:
+            return await self.engine.analyze_market()
         start_amount = 1.0
         token1_amt = await self.router.get_best_quote(self.token0, self.token1, start_amount)
         end_amount = await self.router.get_best_quote(self.token1, self.token0, token1_amt)
         return {"start": start_amount, "end": end_amount}
 
     async def generate_signals(self, market_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if self.engine and isinstance(market_data.get("opportunities"), list):
+            return await self.engine.generate_signals(market_data)
         return self._check_profitability(market_data["start"], market_data["end"])
 
     async def execute_trades(self, signals: List[Dict[str, Any]]) -> List[str]:
+        if self.engine and signals and hasattr(signals[0], "opportunity_type"):
+            return await self.engine.execute_trades(signals)  # type: ignore[arg-type]
         txs: List[str] = []
         for _ in signals:
             self.logger.warning("--- EXECUTION LOGIC DISABLED IN THIS EXAMPLE ---")

--- a/strategies/registry.py
+++ b/strategies/registry.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Callable, Dict, List, Type
 
 from strategies.base import BaseStrategy
+from strategies.arbitrage import ArbitrageStrategy
+from strategies.arbitrage_engine import ArbitrageEngine
 
 
 class StrategyRegistry:
@@ -13,6 +15,8 @@ class StrategyRegistry:
     def __init__(self) -> None:
         self._strategies: Dict[str, Type[BaseStrategy]] = {}
         self._factories: Dict[str, Callable[..., BaseStrategy]] = {}
+        self.register("arbitrage", ArbitrageStrategy)
+        self.register("arbitrage_engine", ArbitrageEngine)
 
     def register(
         self,
@@ -34,4 +38,4 @@ class StrategyRegistry:
     def list_strategies(self) -> List[str]:
         return list(self._strategies.keys())
 
-__all__ = ["StrategyRegistry"]
+__all__ = ["StrategyRegistry", "ArbitrageStrategy", "ArbitrageEngine"]

--- a/tests/test_arbitrage_engine.py
+++ b/tests/test_arbitrage_engine.py
@@ -1,0 +1,35 @@
+import asyncio
+from typing import List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from strategies.arbitrage_engine import (
+    ArbitrageEngine,
+    ArbitrageOpportunity,
+    ArbitrageType,
+    OpportunityDetector,
+)
+class DummyRouter:
+    def __init__(self) -> None:
+        self.get_best_quote = AsyncMock(side_effect=[1.1, 1.2])
+        self.execute_swap = AsyncMock(return_value="0xtx")
+
+
+@pytest.mark.asyncio
+async def test_detector_finds_opportunity():
+    router = DummyRouter()
+    detector = OpportunityDetector(router, ["a", "b"], amount=1)
+    opps = await detector.scan()
+    assert opps
+    assert opps[0].opportunity_type is ArbitrageType.SIMPLE
+
+
+@pytest.mark.asyncio
+async def test_engine_executes_trade():
+    router = DummyRouter()
+    engine = ArbitrageEngine(router, tokens=["a", "b"])
+    market = await engine.analyze_market()
+    signals = await engine.generate_signals(market)
+    txs = await engine.execute_trades(signals)
+    assert txs == ["0xtx"]

--- a/tests/test_cross_chain.py
+++ b/tests/test_cross_chain.py
@@ -1,0 +1,30 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cross_chain import LayerZeroBridge, BridgeError
+
+
+class DummyService:
+    async def sign_and_send_transaction(self, tx, timeout=120, retries=3):
+        return {"hash": "0x1"}
+
+
+@pytest.mark.asyncio
+async def test_bridge_send():
+    service = DummyService()
+    bridge = LayerZeroBridge(service)
+    result = await bridge.send("a", 1, "chain", "addr")
+    assert result == {"hash": "0x1"}
+
+
+@pytest.mark.asyncio
+async def test_bridge_send_error():
+    class FailingService(DummyService):
+        async def sign_and_send_transaction(self, tx, timeout=120, retries=3):
+            raise RuntimeError("fail")
+
+    bridge = LayerZeroBridge(FailingService())
+    with pytest.raises(BridgeError):
+        await bridge.send("a", 1, "chain", "addr")

--- a/tests/test_flash_loans.py
+++ b/tests/test_flash_loans.py
@@ -1,0 +1,47 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from flash_loans import FlashLoanExecutor, FlashLoanProvider, FlashLoanError
+
+
+class DummyProvider(FlashLoanProvider):
+    async def borrow(self, token: str, amount: int) -> str:
+        return "borrow"
+
+    async def repay(self, token: str, amount: int) -> str:
+        return "repay"
+
+
+@pytest.mark.asyncio
+async def test_flash_loan_executor():
+    provider = DummyProvider.__new__(DummyProvider)
+    DummyProvider.__init__(provider, service=None)  # type: ignore[arg-type]
+    provider.borrow = AsyncMock(return_value="borrow")
+    provider.repay = AsyncMock(return_value="repay")
+
+    async def trade() -> str:
+        return "tx"
+
+    executor = FlashLoanExecutor(provider)
+    tx = await executor.execute("a", 1, trade)
+    assert tx == "tx"
+    provider.borrow.assert_awaited_once()
+    provider.repay.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flash_loan_executor_handles_error():
+    provider = DummyProvider.__new__(DummyProvider)
+    DummyProvider.__init__(provider, service=None)  # type: ignore[arg-type]
+    provider.borrow = AsyncMock(return_value="borrow")
+    provider.repay = AsyncMock(return_value="repay")
+
+    async def trade() -> str:
+        raise RuntimeError("fail")
+
+    executor = FlashLoanExecutor(provider)
+    with pytest.raises(FlashLoanError):
+        await executor.execute("a", 1, trade)
+    provider.repay.assert_awaited()

--- a/tests/test_profit_optimizer.py
+++ b/tests/test_profit_optimizer.py
@@ -1,0 +1,7 @@
+from optimization import ProfitOptimizer
+
+
+def test_profit_optimizer_allocation():
+    opt = ProfitOptimizer(max_capital=100)
+    alloc = opt.optimize([1.0, 2.0, 0.5])
+    assert alloc == [0.0, 100, 0.0]

--- a/tests/test_risk_manager_inventory.py
+++ b/tests/test_risk_manager_inventory.py
@@ -1,0 +1,14 @@
+from risk_manager import RiskManager
+
+
+def test_inventory_management():
+    rm = RiskManager()
+    rm.add_inventory("tok", 10)
+    rm.remove_inventory("tok", 5)
+    assert rm.get_inventory("tok") == 5
+
+
+def test_impermanent_loss():
+    rm = RiskManager()
+    loss = rm.impermanent_loss(1.0, 2.0, 1.0, 1.0)
+    assert loss > 0


### PR DESCRIPTION
## Summary
- implement `ArbitrageEngine` with opportunity detection
- add flash-loan provider/executor utilities
- implement simple cross-chain bridge interfaces
- provide profit optimizer helper
- extend `RiskManager` with inventory tracking and impermanent loss checks
- delegate to engine in `ArbitrageStrategy` when enabled
- register new strategies
- add unit tests for new functionality

## Testing
- `pytest tests/test_arbitrage_engine.py tests/test_flash_loans.py tests/test_cross_chain.py tests/test_profit_optimizer.py tests/test_risk_manager_inventory.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b85f3b47c8322b3d81178e86ba62b