### PR TITLE
Add flash loan providers and flash arbitrage executor

### DIFF
--- a/flash_loans/__init__.py
+++ b/flash_loans/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Flash loan utilities."""
+"""Flash loan utilities and providers."""
 
 from abc import ABC, abstractmethod
 from typing import Awaitable, Callable
@@ -49,4 +49,83 @@ class FlashLoanExecutor:
         return tx
 
 
-__all__ = ["FlashLoanProvider", "FlashLoanExecutor", "FlashLoanError"]
+class AaveFlashLoanProvider(FlashLoanProvider):
+    """Stub provider for Aave flash loans."""
+
+    async def borrow(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid borrow args")
+        try:
+            tx = {"to": "aave", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+    async def repay(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid repay args")
+        try:
+            tx = {"to": "aave", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+
+class DyDxFlashLoanProvider(FlashLoanProvider):
+    """Stub provider for dYdX flash loans."""
+
+    async def borrow(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid borrow args")
+        try:
+            tx = {"to": "dydx", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+    async def repay(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid repay args")
+        try:
+            tx = {"to": "dydx", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+
+class BalancerFlashLoanProvider(FlashLoanProvider):
+    """Stub provider for Balancer flash loans."""
+
+    async def borrow(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid borrow args")
+        try:
+            tx = {"to": "balancer", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+    async def repay(self, token: str, amount: int) -> str:
+        if not token or amount <= 0:
+            raise FlashLoanError("invalid repay args")
+        try:
+            tx = {"to": "balancer", "value": 0}
+            receipt = await self.service.sign_and_send_transaction(tx)
+            return receipt["transactionHash"].hex()
+        except Exception as exc:  # noqa: BLE001
+            raise FlashLoanError(str(exc)) from exc
+
+
+__all__ = [
+    "FlashLoanProvider",
+    "FlashLoanExecutor",
+    "FlashLoanError",
+    "AaveFlashLoanProvider",
+    "DyDxFlashLoanProvider",
+    "BalancerFlashLoanProvider",
+]

--- a/flash_loans/arbitrage.py
+++ b/flash_loans/arbitrage.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Flash loan based arbitrage executor."""
+
+import asyncio
+from typing import Awaitable, Callable
+
+from risk_manager import RiskManager
+from utils.retry import retry_async
+from web3_service import Web3Service
+
+from . import FlashLoanError, FlashLoanProvider
+
+
+class FlashArbitrageError(Exception):
+    """Raised when flash arbitrage execution fails."""
+
+
+class FlashArbitrageExecutor:
+    """Execute arbitrage trades using flash loans."""
+
+    def __init__(
+        self,
+        provider: FlashLoanProvider,
+        service: Web3Service,
+        risk_manager: RiskManager | None = None,
+    ) -> None:
+        self.provider = provider
+        self.service = service
+        self.risk_manager = risk_manager or RiskManager()
+
+    async def execute(
+        self,
+        token: str,
+        capital: float,
+        trade_fn: Callable[[int], Awaitable[str]],
+        risk: float = 0.02,
+        timeout: float = 30.0,
+        retries: int = 3,
+    ) -> str:
+        if not token or capital <= 0 or risk <= 0:
+            raise FlashArbitrageError("invalid arguments")
+        amount = int(self.risk_manager.position_size(capital, risk))
+
+        async def _borrow() -> str:
+            return await asyncio.wait_for(
+                self.provider.borrow(token, amount), timeout
+            )
+
+        async def _repay() -> str:
+            return await asyncio.wait_for(
+                self.provider.repay(token, amount), timeout
+            )
+
+        async def _trade() -> str:
+            return await asyncio.wait_for(trade_fn(amount), timeout)
+
+        await retry_async(_borrow, retries=retries)
+        try:
+            tx = await retry_async(_trade, retries=retries)
+        except Exception as exc:  # noqa: BLE001
+            await retry_async(_repay, retries=retries)
+            raise FlashArbitrageError(str(exc)) from exc
+        await retry_async(_repay, retries=retries)
+        return tx
+
+
+__all__ = ["FlashArbitrageExecutor", "FlashArbitrageError"]

--- a/tests/test_flash_arbitrage_executor.py
+++ b/tests/test_flash_arbitrage_executor.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from flash_loans.arbitrage import FlashArbitrageExecutor, FlashArbitrageError
+from flash_loans import FlashLoanProvider
+from risk_manager import RiskManager
+from web3_service import Web3Service
+
+
+class DummyProvider(FlashLoanProvider):
+    async def borrow(self, token: str, amount: int) -> str:
+        return "borrow"
+
+    async def repay(self, token: str, amount: int) -> str:
+        return "repay"
+
+
+def _service() -> Web3Service:
+    svc = Web3Service.__new__(Web3Service)
+    svc.sign_and_send_transaction = AsyncMock(return_value={"transactionHash": b"0x1"})
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_arbitrage_executor_success():
+    service = _service()
+    provider = DummyProvider(service)
+    provider.borrow = AsyncMock(return_value="b")
+    provider.repay = AsyncMock(return_value="r")
+
+    async def trade(amount: int) -> str:
+        return "tx"
+
+    executor = FlashArbitrageExecutor(provider, service, RiskManager())
+    tx = await executor.execute("tok", 1000.0, trade)
+    assert tx == "tx"
+    provider.borrow.assert_awaited_once()
+    provider.repay.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arbitrage_executor_trade_fail():
+    service = _service()
+    provider = DummyProvider(service)
+    provider.borrow = AsyncMock(return_value="b")
+    provider.repay = AsyncMock(return_value="r")
+
+    async def trade(amount: int) -> str:
+        raise RuntimeError("fail")
+
+    executor = FlashArbitrageExecutor(provider, service, RiskManager())
+    with pytest.raises(FlashArbitrageError):
+        await executor.execute("tok", 1000.0, trade)
+    provider.repay.assert_awaited()


### PR DESCRIPTION
## Summary
- extend `flash_loans` package with provider stubs for Aave, dYdX and Balancer
- add new `FlashArbitrageExecutor` with retry and timeout logic
- include tests for flash loan arbitrage executor

## Testing
- `pytest tests/test_flash_arbitrage_executor.py tests/test_flash_loans.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b87a213008322a95a581e3e35c084