### PR TITLE
Add triangular cycle routing and bridge provider

### DIFF
--- a/cross_chain/__init__.py
+++ b/cross_chain/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from web3_service import Web3Service
+from .bridge_provider import BridgeProvider, HttpBridgeProvider, BridgeProviderError
 
 
 class BridgeError(Exception):
@@ -46,4 +47,13 @@ class WormholeBridge(Bridge):
             raise BridgeError(str(exc)) from exc
 
 
-__all__ = ["Bridge", "LayerZeroBridge", "CCIPBridge", "WormholeBridge", "BridgeError"]
+__all__ = [
+    "Bridge",
+    "LayerZeroBridge",
+    "CCIPBridge",
+    "WormholeBridge",
+    "BridgeError",
+    "BridgeProvider",
+    "HttpBridgeProvider",
+    "BridgeProviderError",
+]

--- a/cross_chain/bridge_provider.py
+++ b/cross_chain/bridge_provider.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Bridge price providers for cross-chain arbitrage."""
+
+from abc import ABC, abstractmethod
+
+import httpx
+
+
+class BridgeProviderError(Exception):
+    """Raised when bridge price retrieval fails."""
+
+
+class BridgeProvider(ABC):
+    """Abstract bridge price provider."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+
+    @abstractmethod
+    async def get_price(self, token: str, chain: str) -> float:
+        """Return ``token`` price on ``chain``."""
+
+
+class HttpBridgeProvider(BridgeProvider):
+    async def get_price(self, token: str, chain: str) -> float:
+        if not token or not chain:
+            raise BridgeProviderError("invalid parameters")
+        url = f"{self.base_url}/{chain}/{token}"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                data = resp.json()
+            return float(data["price"])
+        except Exception as exc:  # noqa: BLE001
+            raise BridgeProviderError(str(exc)) from exc
+
+
+__all__ = ["BridgeProvider", "HttpBridgeProvider", "BridgeProviderError"]

--- a/tests/test_arbitrage_engine.py
+++ b/tests/test_arbitrage_engine.py
@@ -14,6 +14,7 @@ class DummyRouter:
     def __init__(self) -> None:
         self.get_best_quote = AsyncMock(side_effect=[1.1, 1.2])
         self.execute_swap = AsyncMock(return_value="0xtx")
+        self.find_triangular_cycles = lambda: []
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge_provider.py
+++ b/tests/test_bridge_provider.py
@@ -1,0 +1,46 @@
+import pytest
+
+from cross_chain.bridge_provider import HttpBridgeProvider, BridgeProviderError
+
+
+class DummyClient:
+    def __init__(self, data):
+        self.data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url):
+        return self
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.data
+
+
+@pytest.mark.asyncio
+async def test_get_price(monkeypatch):
+    monkeypatch.setattr(
+        "httpx.AsyncClient",
+        lambda timeout=10: DummyClient({"price": 5.0}),
+    )
+    provider = HttpBridgeProvider("http://api")
+    price = await provider.get_price("token", "chain")
+    assert price == 5.0
+
+
+@pytest.mark.asyncio
+async def test_get_price_error(monkeypatch):
+    class FailClient(DummyClient):
+        async def get(self, url):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout=10: FailClient({}))
+    provider = HttpBridgeProvider("http://api")
+    with pytest.raises(BridgeProviderError):
+        await provider.get_price("token", "chain")

--- a/tests/test_router_cycles.py
+++ b/tests/test_router_cycles.py
@@ -1,0 +1,32 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from routing import Router
+from dex_protocols.base import LiquidityInfo
+
+
+class DummyProto:
+    def __init__(self, pools, name: str):
+        self.pools = pools
+        self.name = name
+        self.get_quote = AsyncMock(return_value=1.1)
+        self.execute_swap = AsyncMock(return_value=f"tx-{name}")
+        service = MagicMock()
+        service.web3.eth.gas_price = 0
+        self.web3_service = service
+        self.gas_limit = 0
+        self.liq = LiquidityInfo(liquidity=100.0, price_impact=2.0)
+
+    async def get_liquidity_info(self, *_: str) -> LiquidityInfo:
+        return self.liq
+
+
+@pytest.mark.asyncio
+async def test_find_triangular_cycles():
+    p1 = DummyProto([("a", "b", 0)], "p1")
+    p2 = DummyProto([("b", "c", 0)], "p2")
+    p3 = DummyProto([("c", "a", 0)], "p3")
+    router = Router([p1, p2, p3])
+
+    cycles = router.find_triangular_cycles()
+    assert any(c[1] == ["a", "b", "c", "a"] for c in cycles)

--- a/tests/test_triangular_opportunity.py
+++ b/tests/test_triangular_opportunity.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from cross_chain.bridge_provider import BridgeProvider
+from strategies.arbitrage_engine import (
+    ArbitrageType,
+    OpportunityDetector,
+)
+from routing import Router
+from dex_protocols.base import LiquidityInfo
+
+
+class DummyProvider(BridgeProvider):
+    def __init__(self) -> None:
+        super().__init__("http://test")
+
+    async def get_price(self, token: str, chain: str) -> float:
+        return 0.0
+
+
+class DummyProto:
+    def __init__(self, pools, name: str):
+        self.pools = pools
+        self.name = name
+        self.get_quote = AsyncMock(return_value=1.1)
+        self.execute_swap = AsyncMock(return_value=f"tx-{name}")
+        service = MagicMock()
+        service.web3.eth.gas_price = 0
+        self.web3_service = service
+        self.gas_limit = 0
+        self.liq = LiquidityInfo(liquidity=100.0, price_impact=0.0)
+
+    async def get_liquidity_info(self, *_: str) -> LiquidityInfo:
+        return self.liq
+
+
+@pytest.mark.asyncio
+async def test_detector_triangular_cycle():
+    p1 = DummyProto([("a", "b", 0)], "p1")
+    p2 = DummyProto([("b", "c", 0)], "p2")
+    p3 = DummyProto([("c", "a", 0)], "p3")
+    router = Router([p1, p2, p3])
+    router.slippage_engine = None
+    detector = OpportunityDetector(router, ["a", "b", "c"], amount=1, providers=[DummyProvider()])
+    opps = await detector.scan()
+    assert any(o.opportunity_type is ArbitrageType.TRIANGULAR for o in opps)


### PR DESCRIPTION
## Summary
- add `Router.find_triangular_cycles` for detecting A->B->C->A paths
- introduce `BridgeProvider` interface for cross-chain prices
- evaluate triangular cycles in `OpportunityDetector`
- unit tests for cycle detection and bridge provider

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b88e0e9508322915a179e8471b846