### PR TITLE
Implement LP ProfitOptimizer with metrics

### DIFF
--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -10,6 +10,18 @@ SLIPPAGE_CHECKS = Counter('slippage_checks_total', 'Number of slippage checks')
 SLIPPAGE_REJECTED = Counter(
     'slippage_rejected_total', 'Trades rejected due to slippage'
 )
+OPTIMIZATION_RUNS = Counter(
+    'optimization_runs_total',
+    'Number of profit optimization executions',
+)
+OPTIMIZATION_FAILURES = Counter(
+    'optimization_failures_total',
+    'Number of failed profit optimization attempts',
+)
+RISK_ADJUSTED_PROFIT = Histogram(
+    'risk_adjusted_profit',
+    'Risk-adjusted profit from optimizer',
+)
 __all__ = [
     'TRADE_COUNT',
     'TRADE_SUCCESS',
@@ -17,4 +29,7 @@ __all__ = [
     'API_LATENCY',
     'SLIPPAGE_CHECKS',
     'SLIPPAGE_REJECTED',
+    'OPTIMIZATION_RUNS',
+    'OPTIMIZATION_FAILURES',
+    'RISK_ADJUSTED_PROFIT',
 ]

--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -2,25 +2,66 @@ from __future__ import annotations
 
 """Profit optimization utilities."""
 
+from dataclasses import dataclass
 from typing import List
+
+import pulp
+
+from exceptions import StrategyError
+from observability.metrics import (
+    OPTIMIZATION_FAILURES,
+    OPTIMIZATION_RUNS,
+    RISK_ADJUSTED_PROFIT,
+)
+from slippage_protection import calculate_dynamic_slippage
+
+
+@dataclass
+class Opportunity:
+    """Represents a trading opportunity."""
+
+    expected_profit: float
+    risk: float
+    gas_cost: float
+    price_impact: float
+    volatility: float
 
 
 class ProfitOptimizer:
-    """Naive linear optimization for position sizing."""
+    """Linear programming based optimizer for capital allocation."""
 
     def __init__(self, max_capital: float) -> None:
         if max_capital <= 0:
             raise ValueError("max_capital must be positive")
         self.max_capital = max_capital
 
-    def optimize(self, expected_profits: List[float]) -> List[float]:
-        """Allocate capital to the most profitable opportunity."""
-        if not expected_profits:
+    def optimize(
+        self,
+        options: List[Opportunity],
+        risk_weight: float = 1.0,
+        gas_weight: float = 1.0,
+    ) -> List[float]:
+        """Return capital allocation for ``options``."""
+        if not options:
             return []
-        idx = max(range(len(expected_profits)), key=lambda i: expected_profits[i])
-        allocation = [0.0 for _ in expected_profits]
-        allocation[idx] = self.max_capital
+        problem = pulp.LpProblem("profit_opt", pulp.LpMaximize)
+        vars = [pulp.LpVariable(f"alloc_{i}", lowBound=0) for i in range(len(options))]
+        problem += pulp.lpSum(vars) <= self.max_capital
+        profits = []
+        for opt in options:
+            slip = calculate_dynamic_slippage(opt.price_impact, opt.volatility)
+            profits.append(
+                opt.expected_profit - risk_weight * opt.risk - gas_weight * opt.gas_cost - slip
+            )
+        problem += pulp.lpSum(v * p for v, p in zip(vars, profits))
+        status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+        if status != pulp.LpStatusOptimal:
+            OPTIMIZATION_FAILURES.inc()
+            raise StrategyError("optimization failed")
+        OPTIMIZATION_RUNS.inc()
+        allocation = [float(v.varValue or 0.0) for v in vars]
+        RISK_ADJUSTED_PROFIT.observe(sum(p * a for p, a in zip(profits, allocation)))
         return allocation
 
 
-__all__ = ["ProfitOptimizer"]
+__all__ = ["ProfitOptimizer", "Opportunity"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ httpx
 python-json-logger
 prometheus-client
 hypothesis
+pulp
 

--- a/tests/test_profit_optimizer.py
+++ b/tests/test_profit_optimizer.py
@@ -1,7 +1,32 @@
-from optimization import ProfitOptimizer
+import pytest
+
+from optimization import Opportunity, ProfitOptimizer
+from observability.metrics import OPTIMIZATION_FAILURES, OPTIMIZATION_RUNS
 
 
-def test_profit_optimizer_allocation():
+def test_profit_optimizer_allocation(monkeypatch):
+    monkeypatch.setattr(
+        'optimization.calculate_dynamic_slippage',
+        lambda impact, vol: impact * vol * 2,
+    )
+    opts = [
+        Opportunity(5.0, 1.0, 0.5, 0.1, 0.2),
+        Opportunity(4.0, 0.2, 0.1, 0.05, 0.1),
+    ]
     opt = ProfitOptimizer(max_capital=100)
-    alloc = opt.optimize([1.0, 2.0, 0.5])
-    assert alloc == [0.0, 100, 0.0]
+    start = OPTIMIZATION_RUNS._value.get()
+    alloc = opt.optimize(opts)
+    assert alloc == [0.0, 100.0]
+    assert OPTIMIZATION_RUNS._value.get() == start + 1
+
+
+def test_optimizer_metrics(monkeypatch):
+    monkeypatch.setattr(
+        'optimization.pulp.LpProblem.solve',
+        lambda self, *a, **kw: -1,
+    )
+    opt = ProfitOptimizer(max_capital=10)
+    start_fail = OPTIMIZATION_FAILURES._value.get()
+    with pytest.raises(Exception):
+        opt.optimize([Opportunity(1.0, 1.0, 1.0, 0.1, 0.1)])
+    assert OPTIMIZATION_FAILURES._value.get() == start_fail + 1


### PR DESCRIPTION
## Summary
- add optimization metrics
- rewrite `ProfitOptimizer` to use linear programming
- add PuLP dependency
- test optimizer logic and metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8aeeed448322844462d5d01e09fc