### PR TITLE
Add portfolio management components

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,6 +67,13 @@ class SlippageProtectionSettings(BaseModel):
     max_slippage_bps: int = Field(50, ge=0)
 
 
+class PortfolioSettings(BaseModel):
+    """Portfolio management parameters."""
+
+    rebalance_threshold: float = Field(0.05, ge=0, le=1)
+    max_assets: int = Field(20, ge=1)
+
+
 class AppConfig(BaseModel):
     """Validated application configuration."""
 
@@ -91,6 +98,7 @@ class AppConfig(BaseModel):
     mev: MevProtectionSettings
     batch: BatchSettings
     slippage_protection: SlippageProtectionSettings
+    portfolio: PortfolioSettings
 
     @validator(
         "wallet_address",
@@ -186,6 +194,12 @@ class ConfigManager:
                 == "true",
                 "max_slippage_bps": int(os.getenv("MAX_SLIPPAGE_BPS", 50)),
             },
+            "portfolio": {
+                "rebalance_threshold": float(
+                    os.getenv("REBALANCE_THRESHOLD", 0.05)
+                ),
+                "max_assets": int(os.getenv("MAX_PORTFOLIO_ASSETS", 20)),
+            },
         }
 
     def _build_config(self) -> AppConfig:
@@ -237,6 +251,8 @@ def _update_globals(cfg: AppConfig) -> None:
         "MULTICALL_ADDRESS": cfg.batch.multicall_address,
         "DYNAMIC_SLIPPAGE_ENABLED": cfg.slippage_protection.dynamic_slippage_enabled,
         "MAX_SLIPPAGE_BPS": cfg.slippage_protection.max_slippage_bps,
+        "REBALANCE_THRESHOLD": cfg.portfolio.rebalance_threshold,
+        "MAX_PORTFOLIO_ASSETS": cfg.portfolio.max_assets,
     }
     globals().update(mapping)
 
@@ -275,6 +291,8 @@ BATCH_TRANSACTIONS_ENABLED = cfg.batch.enabled
 MULTICALL_ADDRESS = cfg.batch.multicall_address
 DYNAMIC_SLIPPAGE_ENABLED = cfg.slippage_protection.dynamic_slippage_enabled
 MAX_SLIPPAGE_BPS = cfg.slippage_protection.max_slippage_bps
+REBALANCE_THRESHOLD = cfg.portfolio.rebalance_threshold
+MAX_PORTFOLIO_ASSETS = cfg.portfolio.max_assets
 
 __all__ = [
     "CONFIG_MANAGER",
@@ -309,4 +327,6 @@ __all__ = [
     "MULTICALL_ADDRESS",
     "DYNAMIC_SLIPPAGE_ENABLED",
     "MAX_SLIPPAGE_BPS",
+    "REBALANCE_THRESHOLD",
+    "MAX_PORTFOLIO_ASSETS",
 ]

--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, Gauge
 
 TRADE_COUNT = Counter('trade_count_total', 'Number of trades executed')
 TRADE_SUCCESS = Counter('trade_success_total', 'Number of successful trades')
@@ -22,6 +22,8 @@ RISK_ADJUSTED_PROFIT = Histogram(
     'risk_adjusted_profit',
     'Risk-adjusted profit from optimizer',
 )
+PORTFOLIO_VALUE = Gauge('portfolio_value', 'Total portfolio value')
+REBALANCE_COUNT = Counter('portfolio_rebalance_total', 'Number of portfolio rebalances')
 __all__ = [
     'TRADE_COUNT',
     'TRADE_SUCCESS',
@@ -32,4 +34,6 @@ __all__ = [
     'OPTIMIZATION_RUNS',
     'OPTIMIZATION_FAILURES',
     'RISK_ADJUSTED_PROFIT',
+    'PORTFOLIO_VALUE',
+    'REBALANCE_COUNT',
 ]

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,0 +1,5 @@
+from .assets import Asset, Portfolio
+from .manager import PortfolioManager
+from .rebalancing import RebalancingEngine
+
+__all__ = ["Asset", "Portfolio", "PortfolioManager", "RebalancingEngine"]

--- a/portfolio/analytics/__init__.py
+++ b/portfolio/analytics/__init__.py
@@ -1,0 +1,5 @@
+from .correlation import CorrelationEngine
+from .risk_metrics import RiskMetricsEngine
+from .optimizer import OptimizationEngine
+
+__all__ = ["CorrelationEngine", "RiskMetricsEngine", "OptimizationEngine"]

--- a/portfolio/analytics/correlation.py
+++ b/portfolio/analytics/correlation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class CorrelationEngine:
+    """Compute pairwise return correlations."""
+
+    def __init__(self) -> None:
+        self._circuit = CircuitBreaker()
+
+    async def compute(self, returns: Dict[str, List[float]]) -> Dict[Tuple[str, str], float]:
+        async def _compute() -> Dict[Tuple[str, str], float]:
+            result: Dict[Tuple[str, str], float] = {}
+            symbols = list(returns)
+            for i, a in enumerate(symbols):
+                for b in symbols[i + 1 :]:
+                    ra = returns[a]
+                    rb = returns[b]
+                    if not ra or not rb:
+                        result[(a, b)] = 0.0
+                        continue
+                    mean_a = sum(ra) / len(ra)
+                    mean_b = sum(rb) / len(rb)
+                    cov = sum((x - mean_a) * (y - mean_b) for x, y in zip(ra, rb)) / len(ra)
+                    var_a = sum((x - mean_a) ** 2 for x in ra) / len(ra)
+                    var_b = sum((y - mean_b) ** 2 for y in rb) / len(rb)
+                    denom = (var_a * var_b) ** 0.5
+                    result[(a, b)] = cov / denom if denom else 0.0
+            return result
+
+        return await self._circuit.call(retry_async, _compute)
+
+
+__all__ = ["CorrelationEngine"]

--- a/portfolio/analytics/optimizer.py
+++ b/portfolio/analytics/optimizer.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from pulp import LpMaximize, LpProblem, LpVariable, lpSum
+
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class OptimizationEngine:
+    """Simple mean-variance optimizer."""
+
+    def __init__(self) -> None:
+        self._circuit = CircuitBreaker()
+
+    async def optimize(self, returns: Dict[str, float], capital: float) -> Dict[str, float]:
+        async def _opt() -> Dict[str, float]:
+            symbols = list(returns)
+            prob = LpProblem("portfolio", LpMaximize)
+            weights = {s: LpVariable(s, lowBound=0) for s in symbols}
+            prob += lpSum(returns[s] * weights[s] for s in symbols)
+            prob += lpSum(weights[s] for s in symbols) == capital
+            if prob.solve() != 1:
+                raise RuntimeError("optimization failed")
+            return {s: weights[s].value() or 0.0 for s in symbols}
+
+        return await self._circuit.call(retry_async, _opt)
+
+
+__all__ = ["OptimizationEngine"]

--- a/portfolio/analytics/risk_metrics.py
+++ b/portfolio/analytics/risk_metrics.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import List
+
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class RiskMetricsEngine:
+    """Calculate risk measures like VaR."""
+
+    def __init__(self) -> None:
+        self._circuit = CircuitBreaker()
+
+    async def var(self, returns: List[float], confidence: float = 0.95) -> float:
+        async def _var() -> float:
+            if not returns:
+                return 0.0
+            sorted_r = sorted(returns)
+            idx = max(0, int((1 - confidence) * len(sorted_r)) - 1)
+            return abs(sorted_r[idx])
+
+        return await self._circuit.call(retry_async, _var)
+
+
+__all__ = ["RiskMetricsEngine"]

--- a/portfolio/assets.py
+++ b/portfolio/assets.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Asset:
+    """Represent a portfolio asset."""
+
+    symbol: str
+    amount: float
+    price: float
+
+    @property
+    def value(self) -> float:
+        return self.amount * self.price
+
+
+@dataclass
+class Portfolio:
+    """Collection of assets."""
+
+    assets: Dict[str, Asset] = field(default_factory=dict)
+
+    def total_value(self) -> float:
+        return sum(asset.value for asset in self.assets.values())

--- a/portfolio/attribution/__init__.py
+++ b/portfolio/attribution/__init__.py
@@ -1,0 +1,3 @@
+from .performance import attribute_returns
+
+__all__ = ["attribute_returns"]

--- a/portfolio/attribution/performance.py
+++ b/portfolio/attribution/performance.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def attribute_returns(weights: Dict[str, float], returns: Dict[str, List[float]]) -> Dict[str, float]:
+    """Compute contribution of each asset to portfolio return."""
+    contrib: Dict[str, float] = {}
+    periods = len(next(iter(returns.values()), []))
+    if periods == 0:
+        return {k: 0.0 for k in weights}
+    for symbol, weight in weights.items():
+        r = sum(returns.get(symbol, [0.0] * periods)) / periods
+        contrib[symbol] = weight * r
+    return contrib
+
+
+__all__ = ["attribute_returns"]

--- a/portfolio/manager.py
+++ b/portfolio/manager.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from exceptions import InventoryError
+from logger import get_logger
+from risk_manager import RiskManager
+from .assets import Asset, Portfolio
+from .rebalancing import RebalancingEngine
+from observability.metrics import PORTFOLIO_VALUE
+
+
+class PortfolioManager(RiskManager):
+    """Manage assets and perform rebalancing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.portfolio = Portfolio()
+        self.rebalancer = RebalancingEngine()
+        self.logger = get_logger("portfolio_manager")
+
+    def add_asset(self, symbol: str, amount: float, price: float) -> None:
+        if amount < 0 or price <= 0:
+            raise InventoryError("invalid amount or price")
+        self.add_inventory(symbol, amount)
+        self.set_price(symbol, price)
+        self.portfolio.assets[symbol] = Asset(symbol, amount, price)
+        PORTFOLIO_VALUE.set(self.portfolio.total_value())
+
+    def update_price(self, symbol: str, price: float) -> None:
+        self.set_price(symbol, price)
+        asset = self.portfolio.assets.get(symbol)
+        if asset:
+            asset.price = price
+        PORTFOLIO_VALUE.set(self.portfolio.total_value())
+
+    async def rebalance(self, target: Dict[str, float]) -> None:
+        await self.rebalancer.rebalance(self, target)
+        PORTFOLIO_VALUE.set(self.portfolio.total_value())
+
+
+__all__ = ["PortfolioManager"]

--- a/portfolio/rebalancing.py
+++ b/portfolio/rebalancing.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import config
+from exceptions import InventoryError
+from logger import get_logger
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+from observability.metrics import REBALANCE_COUNT
+from .assets import Asset
+
+
+class RebalancingEngine:
+    """Perform portfolio rebalancing with safety mechanisms."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger("rebalancing_engine")
+        self._circuit = CircuitBreaker()
+
+    async def rebalance(self, manager: "PortfolioManager", target: Dict[str, float]) -> None:
+        async def _rebalance() -> None:
+            total = manager.portfolio.total_value()
+            if total <= 0:
+                return
+            for symbol, weight in target.items():
+                if weight < 0:
+                    raise InventoryError("negative weight")
+                asset = manager.portfolio.assets.get(symbol)
+                if not asset:
+                    continue
+                desired = total * weight
+                diff = abs(asset.value - desired) / total
+                if diff < config.REBALANCE_THRESHOLD:
+                    continue
+                amount = desired / asset.price
+                manager.inventory[symbol].balance = amount
+                asset.amount = amount
+        await self._circuit.call(retry_async, _rebalance)
+        REBALANCE_COUNT.inc()
+
+
+__all__ = ["RebalancingEngine"]

--- a/tests/test_portfolio_basic.py
+++ b/tests/test_portfolio_basic.py
@@ -1,0 +1,8 @@
+from portfolio import Asset, Portfolio
+
+
+def test_asset_and_portfolio_value():
+    asset = Asset("A", 2, 3.0)
+    p = Portfolio({"A": asset})
+    assert asset.value == 6.0
+    assert p.total_value() == 6.0

--- a/tests/test_portfolio_config.py
+++ b/tests/test_portfolio_config.py
@@ -1,0 +1,9 @@
+import config
+
+
+def test_portfolio_config_reload(monkeypatch):
+    monkeypatch.setenv("REBALANCE_THRESHOLD", "0.1")
+    monkeypatch.setenv("MAX_PORTFOLIO_ASSETS", "30")
+    config.CONFIG_MANAGER.reload()
+    assert config.REBALANCE_THRESHOLD == 0.1
+    assert config.MAX_PORTFOLIO_ASSETS == 30

--- a/tests/test_portfolio_rebalance.py
+++ b/tests/test_portfolio_rebalance.py
@@ -1,0 +1,19 @@
+import asyncio
+
+import pytest
+import config
+from portfolio.manager import PortfolioManager
+from observability.metrics import REBALANCE_COUNT
+
+
+@pytest.mark.asyncio
+async def test_rebalance_engine(monkeypatch):
+    monkeypatch.setattr(config, "REBALANCE_THRESHOLD", 0.0)
+    pm = PortfolioManager()
+    pm.add_asset("A", 10, 1.0)
+    pm.add_asset("B", 5, 2.0)
+    start = REBALANCE_COUNT._value.get()
+    await pm.rebalance({"A": 0.5, "B": 0.5})
+    assert REBALANCE_COUNT._value.get() == start + 1
+    total = pm.portfolio.total_value()
+    assert abs(pm.portfolio.assets["A"].value - total / 2) < 1e-6


### PR DESCRIPTION
## Summary
- implement new `portfolio` package with asset, manager, rebalancing and analytics modules
- create `attribution` and `analytics` subpackages
- extend config with `PortfolioSettings`
- add portfolio metrics for Prometheus
- include unit tests for portfolio features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cada13264832285aa2912d5443398