### PR TITLE
Add advanced portfolio optimizers

### DIFF
--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Profit optimization utilities."""
+"""Profit optimization utilities.
+
+This module provides several linear programming optimizers that use
+`pulp` to determine optimal capital allocations under different models.
+Each optimizer records metrics on successful and failed optimization runs.
+"""
 
 from dataclasses import dataclass
 from typing import List
@@ -64,4 +69,128 @@ class ProfitOptimizer:
         return allocation
 
 
-__all__ = ["ProfitOptimizer", "Opportunity"]
+class MarkowitzOptimizer(ProfitOptimizer):
+    """Mean-variance optimizer using risk aversion."""
+
+    def optimize(
+        self, options: List[Opportunity], risk_aversion: float = 1.0
+    ) -> List[float]:
+        if not options:
+            return []
+        problem = pulp.LpProblem("markowitz_opt", pulp.LpMaximize)
+        vars = [pulp.LpVariable(f"alloc_{i}", lowBound=0) for i in range(len(options))]
+        problem += pulp.lpSum(vars) <= self.max_capital
+        profits = []
+        for opt in options:
+            slip = calculate_dynamic_slippage(opt.price_impact, opt.volatility)
+            profits.append(opt.expected_profit - risk_aversion * opt.risk - slip)
+        problem += pulp.lpSum(v * p for v, p in zip(vars, profits))
+        status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+        if status != pulp.LpStatusOptimal:
+            OPTIMIZATION_FAILURES.inc()
+            raise StrategyError("optimization failed")
+        OPTIMIZATION_RUNS.inc()
+        allocation = [float(v.varValue or 0.0) for v in vars]
+        RISK_ADJUSTED_PROFIT.observe(sum(p * a for p, a in zip(profits, allocation)))
+        return allocation
+
+
+class BlackLittermanOptimizer(ProfitOptimizer):
+    """Optimizer blending expected return with risk views."""
+
+    def optimize(
+        self,
+        options: List[Opportunity],
+        view_weight: float = 0.5,
+        gas_weight: float = 1.0,
+    ) -> List[float]:
+        if not options:
+            return []
+        problem = pulp.LpProblem("black_litterman_opt", pulp.LpMaximize)
+        vars = [pulp.LpVariable(f"alloc_{i}", lowBound=0) for i in range(len(options))]
+        problem += pulp.lpSum(vars) <= self.max_capital
+        profits = []
+        for opt in options:
+            slip = calculate_dynamic_slippage(opt.price_impact, opt.volatility)
+            view = opt.expected_profit - (1 - view_weight) * opt.risk
+            profits.append(view - gas_weight * opt.gas_cost - slip)
+        problem += pulp.lpSum(v * p for v, p in zip(vars, profits))
+        status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+        if status != pulp.LpStatusOptimal:
+            OPTIMIZATION_FAILURES.inc()
+            raise StrategyError("optimization failed")
+        OPTIMIZATION_RUNS.inc()
+        allocation = [float(v.varValue or 0.0) for v in vars]
+        RISK_ADJUSTED_PROFIT.observe(sum(p * a for p, a in zip(profits, allocation)))
+        return allocation
+
+
+class RiskParityOptimizer(ProfitOptimizer):
+    """Allocate capital to achieve equal weights."""
+
+    def optimize(self, options: List[Opportunity]) -> List[float]:
+        if not options:
+            return []
+        problem = pulp.LpProblem("risk_parity_opt", pulp.LpMinimize)
+        vars = [pulp.LpVariable(f"alloc_{i}", lowBound=0) for i in range(len(options))]
+        problem += pulp.lpSum(vars) == self.max_capital
+        target = self.max_capital / len(options)
+        devs = [pulp.LpVariable(f"dev_{i}", lowBound=0) for i in range(len(options))]
+        for v, d in zip(vars, devs):
+            problem += v - target <= d
+            problem += target - v <= d
+        problem += pulp.lpSum(devs)
+        status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+        if status != pulp.LpStatusOptimal:
+            OPTIMIZATION_FAILURES.inc()
+            raise StrategyError("optimization failed")
+        OPTIMIZATION_RUNS.inc()
+        allocation = [float(v.varValue or 0.0) for v in vars]
+        RISK_ADJUSTED_PROFIT.observe(-float(problem.objective.value()))
+        return allocation
+
+
+class FactorModelOptimizer(ProfitOptimizer):
+    """Optimizer with factor exposure constraint."""
+
+    def optimize(
+        self,
+        options: List[Opportunity],
+        exposures: List[float],
+        exposure_limit: float,
+        risk_weight: float = 1.0,
+        gas_weight: float = 1.0,
+    ) -> List[float]:
+        if not options:
+            return []
+        if len(exposures) != len(options):
+            raise ValueError("exposures length mismatch")
+        problem = pulp.LpProblem("factor_model_opt", pulp.LpMaximize)
+        vars = [pulp.LpVariable(f"alloc_{i}", lowBound=0) for i in range(len(options))]
+        problem += pulp.lpSum(vars) <= self.max_capital
+        problem += pulp.lpSum(v * e for v, e in zip(vars, exposures)) <= exposure_limit
+        profits = []
+        for opt in options:
+            slip = calculate_dynamic_slippage(opt.price_impact, opt.volatility)
+            profits.append(
+                opt.expected_profit - risk_weight * opt.risk - gas_weight * opt.gas_cost - slip
+            )
+        problem += pulp.lpSum(v * p for v, p in zip(vars, profits))
+        status = problem.solve(pulp.PULP_CBC_CMD(msg=False))
+        if status != pulp.LpStatusOptimal:
+            OPTIMIZATION_FAILURES.inc()
+            raise StrategyError("optimization failed")
+        OPTIMIZATION_RUNS.inc()
+        allocation = [float(v.varValue or 0.0) for v in vars]
+        RISK_ADJUSTED_PROFIT.observe(sum(p * a for p, a in zip(profits, allocation)))
+        return allocation
+
+
+__all__ = [
+    "ProfitOptimizer",
+    "Opportunity",
+    "MarkowitzOptimizer",
+    "BlackLittermanOptimizer",
+    "RiskParityOptimizer",
+    "FactorModelOptimizer",
+]

--- a/tests/test_additional_optimizers.py
+++ b/tests/test_additional_optimizers.py
@@ -1,0 +1,74 @@
+import pytest
+
+from optimization import (
+    Opportunity,
+    MarkowitzOptimizer,
+    BlackLittermanOptimizer,
+    RiskParityOptimizer,
+    FactorModelOptimizer,
+)
+from observability.metrics import OPTIMIZATION_FAILURES, OPTIMIZATION_RUNS
+
+
+def patch_slippage(monkeypatch):
+    monkeypatch.setattr(
+        "optimization.calculate_dynamic_slippage",
+        lambda impact, vol: impact * vol * 2,
+    )
+
+
+def example_options():
+    return [
+        Opportunity(5.0, 1.0, 0.5, 0.1, 0.2),
+        Opportunity(4.0, 0.2, 0.1, 0.05, 0.1),
+    ]
+
+
+def test_markowitz_optimizer(monkeypatch):
+    patch_slippage(monkeypatch)
+    opt = MarkowitzOptimizer(max_capital=100)
+    alloc = opt.optimize(example_options())
+    assert alloc == [100.0, 0.0]
+
+
+def test_black_litterman_optimizer(monkeypatch):
+    patch_slippage(monkeypatch)
+    opt = BlackLittermanOptimizer(max_capital=100)
+    alloc = opt.optimize(example_options())
+    assert alloc == [100.0, 0.0]
+
+
+def test_risk_parity_optimizer(monkeypatch):
+    patch_slippage(monkeypatch)
+    opt = RiskParityOptimizer(max_capital=100)
+    alloc = opt.optimize(example_options())
+    assert alloc == [50.0, 50.0]
+
+
+def test_factor_model_optimizer(monkeypatch):
+    patch_slippage(monkeypatch)
+    opt = FactorModelOptimizer(max_capital=100)
+    alloc = opt.optimize(example_options(), exposures=[0.5, 0.1], exposure_limit=20)
+    assert alloc == [0.0, 100.0]
+
+
+@pytest.mark.parametrize(
+    "optimizer_cls,args",
+    [
+        (MarkowitzOptimizer, {}),
+        (BlackLittermanOptimizer, {}),
+        (RiskParityOptimizer, {}),
+        (FactorModelOptimizer, {"exposures": [0.1], "exposure_limit": 1}),
+    ],
+)
+def test_optimizers_fail(monkeypatch, optimizer_cls, args):
+    monkeypatch.setattr("optimization.pulp.LpProblem.solve", lambda self, *a, **kw: -1)
+    opt = optimizer_cls(max_capital=10)
+    start_fail = OPTIMIZATION_FAILURES._value.get()
+    with pytest.raises(Exception):
+        options = [Opportunity(1.0, 1.0, 1.0, 0.1, 0.1)]
+        if optimizer_cls is FactorModelOptimizer:
+            opt.optimize(options, **args)
+        else:
+            opt.optimize(options)
+    assert OPTIMIZATION_FAILURES._value.get() == start_fail + 1


### PR DESCRIPTION
## Summary
- extend `optimization` with four new LP optimizers: Markowitz, Black-Litterman, Risk Parity, and Factor Model
- document optimizer module
- test new optimizers for allocation success and failure paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb226505483229069b3d5e7a50c98