### PR TITLE
Refactor bridge send implementation

### DIFF
--- a/cross_chain/__init__.py
+++ b/cross_chain/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Cross-chain bridge interfaces."""
 
-from abc import ABC, abstractmethod
+from abc import ABC
 
 from web3_service import Web3Service
 from .bridge_provider import BridgeProvider, HttpBridgeProvider, BridgeProviderError
@@ -13,38 +13,32 @@ class BridgeError(Exception):
 
 
 class Bridge(ABC):
-    """Abstract bridge base class."""
+    """Bridge base class with common ``send`` implementation."""
 
     def __init__(self, service: Web3Service) -> None:
         self.service = service
 
-    @abstractmethod
     async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
         """Bridge ``token`` to ``dst_chain``."""
+        try:
+            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
+        except Exception as exc:  # noqa: BLE001
+            raise BridgeError(str(exc)) from exc
 
 
 class LayerZeroBridge(Bridge):
-    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
-        try:
-            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
-        except Exception as exc:  # noqa: BLE001
-            raise BridgeError(str(exc)) from exc
+    """Bridge implementation using the LayerZero network."""
+    pass
 
 
 class CCIPBridge(Bridge):
-    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
-        try:
-            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
-        except Exception as exc:  # noqa: BLE001
-            raise BridgeError(str(exc)) from exc
+    """Bridge implementation using CCIP."""
+    pass
 
 
 class WormholeBridge(Bridge):
-    async def send(self, token: str, amount: int, dst_chain: str, address: str) -> str:
-        try:
-            return await self.service.sign_and_send_transaction({"to": address, "value": amount})
-        except Exception as exc:  # noqa: BLE001
-            raise BridgeError(str(exc)) from exc
+    """Bridge implementation using Wormhole."""
+    pass
 
 
 __all__ = [

--- a/tests/test_cross_chain.py
+++ b/tests/test_cross_chain.py
@@ -1,9 +1,12 @@
 import asyncio
-from unittest.mock import AsyncMock
-
 import pytest
 
-from cross_chain import LayerZeroBridge, BridgeError
+from cross_chain import (
+    LayerZeroBridge,
+    CCIPBridge,
+    WormholeBridge,
+    BridgeError,
+)
 
 
 class DummyService:
@@ -12,19 +15,21 @@ class DummyService:
 
 
 @pytest.mark.asyncio
-async def test_bridge_send():
+@pytest.mark.parametrize("bridge_cls", [LayerZeroBridge, CCIPBridge, WormholeBridge])
+async def test_bridge_send(bridge_cls):
     service = DummyService()
-    bridge = LayerZeroBridge(service)
+    bridge = bridge_cls(service)
     result = await bridge.send("a", 1, "chain", "addr")
     assert result == {"hash": "0x1"}
 
 
 @pytest.mark.asyncio
-async def test_bridge_send_error():
+@pytest.mark.parametrize("bridge_cls", [LayerZeroBridge, CCIPBridge, WormholeBridge])
+async def test_bridge_send_error(bridge_cls):
     class FailingService(DummyService):
         async def sign_and_send_transaction(self, tx, timeout=120, retries=3):
             raise RuntimeError("fail")
 
-    bridge = LayerZeroBridge(FailingService())
+    bridge = bridge_cls(FailingService())
     with pytest.raises(BridgeError):
         await bridge.send("a", 1, "chain", "addr")


### PR DESCRIPTION
## Summary
- implement common send method in Bridge base class
- simplify LayerZeroBridge, CCIPBridge, and WormholeBridge
- expand tests for cross_chain bridges

## Testing
- `pytest tests/test_cross_chain.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb55d23888322bec2a6e27211f854