### PR TITLE
Add analytics engine with risk integration

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .engine import AnalyticsEngine, AnalyticsError
+
+__all__ = ["AnalyticsEngine", "AnalyticsError"]

--- a/analytics/engine.py
+++ b/analytics/engine.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+import httpx
+
+from risk_manager import RiskManager
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class AnalyticsError(Exception):
+    """Raised when analytics operations fail."""
+
+
+class AnalyticsEngine:
+    """Compute portfolio analytics and P&L metrics."""
+
+    def __init__(self, risk_manager: RiskManager, base_currency: str = "USD") -> None:
+        self.risk_manager = risk_manager
+        self.base_currency = base_currency
+        self.strategy_returns: Dict[str, List[float]] = defaultdict(list)
+        self.strategy_assets: Dict[str, List[str]] = defaultdict(list)
+        self._circuit = CircuitBreaker()
+
+    async def _fetch_rate(self, src: str, dst: str) -> float:
+        async def _get() -> float:
+            url = os.environ.get("FX_API_URL")
+            key = os.environ.get("FX_API_KEY")
+            if not url or not key:
+                raise AnalyticsError("missing FX API config")
+            params = {"base": src, "symbols": dst, "api_key": key}
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+            return float(data["rates"][dst])
+
+        try:
+            return await self._circuit.call(retry_async, _get)
+        except Exception as exc:  # noqa: BLE001
+            raise AnalyticsError(str(exc)) from exc
+
+    async def _convert_price(self, price: float, src: str) -> float:
+        if src == self.base_currency:
+            return price
+        rate = await self._fetch_rate(src, self.base_currency)
+        return price * rate
+
+    async def update_price(self, token: str, price: float, currency: str) -> None:
+        if price <= 0 or not token:
+            raise AnalyticsError("invalid parameters")
+        conv = await self._convert_price(price, currency)
+        self.risk_manager.set_price(token, conv)
+
+    async def register_asset(
+        self, strategy: str, token: str, amount: float, price: float, currency: str
+    ) -> None:
+        if amount <= 0 or price <= 0 or not strategy or not token:
+            raise AnalyticsError("invalid parameters")
+        conv = await self._convert_price(price, currency)
+        self.risk_manager.add_inventory(token, amount)
+        self.risk_manager.set_price(token, conv)
+        item = self.risk_manager.inventory[token]
+        item.metadata.setdefault("entry_price", conv)
+        self.strategy_assets[strategy].append(token)
+
+    def record_trade(self, strategy: str, pnl: float) -> None:
+        self.strategy_returns[strategy].append(pnl)
+        self.risk_manager.update_equity(pnl)
+
+    def unrealized_pnl(self, token: str) -> float:
+        item = self.risk_manager.inventory.get(token)
+        if not item or "entry_price" not in item.metadata:
+            return 0.0
+        return (item.price - item.metadata["entry_price"]) * item.balance
+
+    def pnl_per_strategy(self, strategy: str) -> Tuple[float, float]:
+        realized = sum(self.strategy_returns.get(strategy, []))
+        unreal = sum(self.unrealized_pnl(t) for t in self.strategy_assets.get(strategy, []))
+        return realized, unreal
+
+    def _ratio(self, returns: List[float], downside: bool = False) -> Tuple[float, float]:
+        if not returns:
+            return 0.0, 0.0
+        avg = sum(returns) / len(returns)
+        if downside:
+            neg = [r for r in returns if r < 0]
+            var = sum(r ** 2 for r in neg) / len(returns)
+        else:
+            var = sum((r - avg) ** 2 for r in returns) / len(returns)
+        return avg, var ** 0.5
+
+    def sortino_ratio(self, returns: List[float], risk_free: float = 0.0) -> float:
+        avg, dd = self._ratio([r - risk_free for r in returns], downside=True)
+        return 0.0 if dd == 0 else avg / dd
+
+    def calmar_ratio(self, returns: List[float]) -> float:
+        max_dd = self.max_drawdown(returns)
+        avg = sum(returns) / len(returns) if returns else 0.0
+        return 0.0 if max_dd == 0 else avg / abs(max_dd)
+
+    def information_ratio(self, returns: List[float], benchmark: List[float]) -> float:
+        diff = [a - b for a, b in zip(returns, benchmark)]
+        avg, std = self._ratio(diff)
+        return 0.0 if std == 0 else avg / std
+
+    def win_rate(self, returns: List[float]) -> float:
+        wins = [r for r in returns if r > 0]
+        return len(wins) / len(returns) if returns else 0.0
+
+    def average_win_loss(self, returns: List[float]) -> Tuple[float, float]:
+        wins = [r for r in returns if r > 0]
+        losses = [r for r in returns if r < 0]
+        avg_win = sum(wins) / len(wins) if wins else 0.0
+        avg_loss = sum(losses) / len(losses) if losses else 0.0
+        return avg_win, avg_loss
+
+    def profit_factor(self, returns: List[float]) -> float:
+        gains = sum(r for r in returns if r > 0)
+        loss = abs(sum(r for r in returns if r < 0))
+        return gains / loss if loss else 0.0
+
+    def rolling(self, returns: List[float], window: int) -> List[float]:
+        if window <= 0:
+            raise AnalyticsError("window must be positive")
+        return [sum(returns[i : i + window]) / window for i in range(len(returns) - window + 1)]
+
+    def max_drawdown(self, returns: List[float]) -> float:
+        peak = drawdown = 0.0
+        cum = 0.0
+        for r in returns:
+            cum += r
+            peak = max(peak, cum)
+            drawdown = min(drawdown, cum - peak)
+        return drawdown
+
+    def beta(self, returns: List[float], benchmark: List[float]) -> float:
+        if not returns or not benchmark:
+            return 0.0
+        mean_r = sum(returns) / len(returns)
+        mean_b = sum(benchmark) / len(benchmark)
+        cov = sum((r - mean_r) * (b - mean_b) for r, b in zip(returns, benchmark)) / len(returns)
+        var_b = sum((b - mean_b) ** 2 for b in benchmark) / len(benchmark)
+        return cov / var_b if var_b else 0.0
+
+
+__all__ = ["AnalyticsEngine", "AnalyticsError"]

--- a/tests/test_analytics_engine.py
+++ b/tests/test_analytics_engine.py
@@ -1,0 +1,81 @@
+import os
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from analytics import AnalyticsEngine, AnalyticsError
+from risk_manager import RiskManager
+
+
+class DummyResp:
+    def __init__(self, rate: float) -> None:
+        self.rate = rate
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return {"rates": {"USD": self.rate}}
+
+
+class DummyClient:
+    def __init__(self, rate: float) -> None:
+        self.rate = rate
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        pass
+
+    async def get(self, *_: str, **__: object) -> DummyResp:
+        return DummyResp(self.rate)
+
+
+@pytest.mark.asyncio
+async def test_register_and_pnl(monkeypatch):
+    os.environ["FX_API_URL"] = "http://test"
+    os.environ["FX_API_KEY"] = "k"
+    rm = RiskManager()
+    engine = AnalyticsEngine(rm)
+    monkeypatch.setattr(engine, "_circuit", SimpleNamespace(call=lambda f, *a, **k: f(*a, **k)))
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout: DummyClient(1.0))
+    await engine.register_asset("s1", "AAA", 1, 100, "EUR")
+    await engine.update_price("AAA", 110, "EUR")
+    realized, unreal = engine.pnl_per_strategy("s1")
+    assert unreal == pytest.approx(10.0)
+    engine.record_trade("s1", 5.0)
+    realized, unreal = engine.pnl_per_strategy("s1")
+    assert realized == 5.0
+
+
+def test_ratios():
+    rm = RiskManager()
+    engine = AnalyticsEngine(rm)
+    returns = [0.1, -0.05, 0.2, -0.1]
+    bench = [0.05, 0.0, 0.1, -0.02]
+    assert engine.win_rate(returns) == 0.5
+    aw, al = engine.average_win_loss(returns)
+    assert aw > 0 and al < 0
+    assert engine.profit_factor(returns) > 1
+    assert engine.max_drawdown(returns) < 0
+    assert engine.sortino_ratio(returns) != 0
+    assert engine.calmar_ratio(returns) != 0
+    assert engine.information_ratio(returns, bench) != 0
+    assert engine.beta(returns, bench) != 0
+    assert engine.rolling(returns, 2) == pytest.approx([0.025, 0.075, 0.05])
+
+
+@pytest.mark.asyncio
+async def test_error_on_bad_window(monkeypatch):
+    rm = RiskManager()
+    engine = AnalyticsEngine(rm)
+    with pytest.raises(AnalyticsError):
+        engine.rolling([0.1], 0)
+
+    monkeypatch.setattr(engine, "_circuit", SimpleNamespace(call=lambda f, *a, **k: f(*a, **k)))
+    os.environ["FX_API_URL"] = "http://t"
+    os.environ["FX_API_KEY"] = "k"
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout: DummyClient(1.2))
+    await engine.update_price("AAA", 1, "EUR")


### PR DESCRIPTION
## Summary
- implement `AnalyticsEngine` to track real-time P&L and risk metrics
- integrate with `RiskManager` and add FX rate support via circuit breaker
- expose new analytics package
- test analytics engine functionality and ratios

## Testing
- `pytest tests/test_analytics_engine.py -q`
- `pytest tests/test_analytics_engine.py --cov=analytics.engine -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccf14a8148322b93c78867e9fe381