### PR TITLE
Add analytics reporting and visualization modules

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,3 +1,25 @@
 from .engine import AnalyticsEngine, AnalyticsError
+from .reporting import (
+    generate_report,
+    export_json,
+    export_csv,
+    ReportingError,
+)
+from .visualization import (
+    prepare_pl_curve,
+    prepare_drawdown,
+    prepare_dashboard_data,
+)
 
-__all__ = ["AnalyticsEngine", "AnalyticsError"]
+__all__ = [
+    "AnalyticsEngine",
+    "AnalyticsError",
+    "generate_report",
+    "export_json",
+    "export_csv",
+    "ReportingError",
+    "prepare_pl_curve",
+    "prepare_drawdown",
+    "prepare_dashboard_data",
+]
+

--- a/analytics/reporting.py
+++ b/analytics/reporting.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+from typing import Any, Dict, List
+
+from logger import get_logger
+from .visualization import prepare_pl_curve, prepare_drawdown
+
+
+logger = get_logger("reporting")
+
+
+class ReportingError(Exception):
+    """Raised when report generation or export fails."""
+
+
+def _aggregate_returns(returns: List[float], window: int) -> List[float]:
+    if window <= 0:
+        raise ReportingError("window must be positive")
+    result: List[float] = []
+    for i in range(0, len(returns), window):
+        result.append(sum(returns[i : i + window]))
+    return result
+
+
+def generate_report(period: str, returns: List[float]) -> Dict[str, float]:
+    if period not in {"daily", "weekly", "monthly"}:
+        raise ReportingError("unsupported period")
+    if not all(isinstance(r, (int, float)) for r in returns):
+        raise ReportingError("invalid returns")
+    window = {"daily": 1, "weekly": 7, "monthly": 30}[period]
+    aggregated = _aggregate_returns(returns, window)
+    pl_curve = prepare_pl_curve(aggregated)
+    drawdown = prepare_drawdown(aggregated)
+    report = {
+        "period": period,
+        "total_pnl": sum(aggregated),
+        "average_pnl": sum(aggregated) / len(aggregated) if aggregated else 0.0,
+        "max_drawdown": min(drawdown) if drawdown else 0.0,
+    }
+    logger.info("generated report", extra={"metadata": report})
+    return report
+
+
+async def export_json(data: Dict[str, Any], path: str) -> None:
+    if not path.lower().endswith(".json"):
+        raise ReportingError("path must end with .json")
+    try:
+        await asyncio.to_thread(_write_json, path, data)
+        logger.info("exported json", extra={"metadata": {"path": path}})
+    except Exception as exc:  # noqa: BLE001
+        logger.error("json export failed: %s", exc)
+        raise ReportingError(str(exc)) from exc
+
+
+def _write_json(path: str, data: Dict[str, Any]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+async def export_csv(data: Dict[str, Any], path: str) -> None:
+    if not path.lower().endswith(".csv"):
+        raise ReportingError("path must end with .csv")
+    try:
+        await asyncio.to_thread(_write_csv, path, data)
+        logger.info("exported csv", extra={"metadata": {"path": path}})
+    except Exception as exc:  # noqa: BLE001
+        logger.error("csv export failed: %s", exc)
+        raise ReportingError(str(exc)) from exc
+
+
+def _write_csv(path: str, data: Dict[str, Any]) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(data.keys())
+        writer.writerow([data[k] for k in data.keys()])
+

--- a/analytics/visualization.py
+++ b/analytics/visualization.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def prepare_pl_curve(returns: List[float]) -> List[float]:
+    curve: List[float] = []
+    total = 0.0
+    for r in returns:
+        total += r
+        curve.append(total)
+    return curve
+
+
+def prepare_drawdown(returns: List[float]) -> List[float]:
+    curve = prepare_pl_curve(returns)
+    drawdown: List[float] = []
+    peak = 0.0
+    for val in curve:
+        peak = max(peak, val)
+        drawdown.append(val - peak)
+    return drawdown
+
+
+def prepare_dashboard_data(returns: List[float]) -> Dict[str, List[float]]:
+    return {
+        "pl_curve": prepare_pl_curve(returns),
+        "drawdown": prepare_drawdown(returns),
+    }
+

--- a/tests/test_reporting_visualization.py
+++ b/tests/test_reporting_visualization.py
@@ -1,0 +1,52 @@
+import json
+import csv
+
+import pytest
+
+from analytics.reporting import (
+    generate_report,
+    export_json,
+    export_csv,
+    ReportingError,
+)
+from analytics.visualization import (
+    prepare_pl_curve,
+    prepare_drawdown,
+    prepare_dashboard_data,
+)
+
+
+def test_prepare_visualization():
+    returns = [1.0, -0.5, 0.2]
+    curve = prepare_pl_curve(returns)
+    assert curve == [1.0, 0.5, 0.7]
+    dd = prepare_drawdown(returns)
+    assert dd == pytest.approx([0.0, -0.5, -0.3])
+    dash = prepare_dashboard_data(returns)
+    assert dash["pl_curve"] == curve
+    assert dash["drawdown"] == dd
+
+
+@pytest.mark.asyncio
+async def test_report_export(tmp_path):
+    returns = [0.1] * 10
+    report = generate_report("daily", returns)
+    json_path = tmp_path / "r.json"
+    csv_path = tmp_path / "r.csv"
+    await export_json(report, str(json_path))
+    await export_csv(report, str(csv_path))
+    with open(json_path, "r", encoding="utf-8") as f:
+        saved = json.load(f)
+    assert saved == report
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    assert rows[0] == list(report.keys())
+    values = dict(zip(rows[0], rows[1]))
+    assert float(values["average_pnl"]) == report["average_pnl"]
+
+
+def test_generate_report_validation():
+    with pytest.raises(ReportingError):
+        generate_report("yearly", [1.0])
+


### PR DESCRIPTION
## Summary
- extend analytics package with reporting and visualization helpers
- export report data as JSON or CSV
- expose helper functions from analytics package
- test new functionality

## Testing
- `pytest --cov=analytics -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd25e909c83228fd980ca5fb0b788