### PR TITLE
Add analytics gauges and export via __all__

### DIFF
--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -10,6 +10,12 @@ from .visualization import (
     prepare_drawdown,
     prepare_dashboard_data,
 )
+from .metrics import (
+    ANALYTICS_PNL,
+    ANALYTICS_DRAWDOWN,
+    ROLLING_PERFORMANCE_7D,
+    ROLLING_PERFORMANCE_30D,
+)
 
 __all__ = [
     "AnalyticsEngine",
@@ -21,5 +27,9 @@ __all__ = [
     "prepare_pl_curve",
     "prepare_drawdown",
     "prepare_dashboard_data",
+    "ANALYTICS_PNL",
+    "ANALYTICS_DRAWDOWN",
+    "ROLLING_PERFORMANCE_7D",
+    "ROLLING_PERFORMANCE_30D",
 ]
 

--- a/analytics/metrics.py
+++ b/analytics/metrics.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from prometheus_client import Gauge
+
+ANALYTICS_PNL = Gauge(
+    "analytics_pnl",
+    "Current cumulative profit and loss computed by the analytics engine",
+)
+ANALYTICS_DRAWDOWN = Gauge(
+    "analytics_drawdown",
+    "Current portfolio drawdown computed by the analytics engine",
+)
+ROLLING_PERFORMANCE_7D = Gauge(
+    "rolling_performance_7d",
+    "Seven-day rolling performance",
+)
+ROLLING_PERFORMANCE_30D = Gauge(
+    "rolling_performance_30d",
+    "Thirty-day rolling performance",
+)
+
+__all__ = [
+    "ANALYTICS_PNL",
+    "ANALYTICS_DRAWDOWN",
+    "ROLLING_PERFORMANCE_7D",
+    "ROLLING_PERFORMANCE_30D",
+]

--- a/tests/test_analytics_metrics.py
+++ b/tests/test_analytics_metrics.py
@@ -1,0 +1,17 @@
+from analytics.metrics import (
+    ANALYTICS_PNL,
+    ANALYTICS_DRAWDOWN,
+    ROLLING_PERFORMANCE_7D,
+    ROLLING_PERFORMANCE_30D,
+)
+
+
+def test_analytics_metrics_gauges():
+    ANALYTICS_PNL.set(10.0)
+    ANALYTICS_DRAWDOWN.set(-2.0)
+    ROLLING_PERFORMANCE_7D.set(0.05)
+    ROLLING_PERFORMANCE_30D.set(0.2)
+    assert ANALYTICS_PNL._value.get() == 10.0
+    assert ANALYTICS_DRAWDOWN._value.get() == -2.0
+    assert ROLLING_PERFORMANCE_7D._value.get() == 0.05
+    assert ROLLING_PERFORMANCE_30D._value.get() == 0.2


### PR DESCRIPTION
## Summary
- add `analytics.metrics` module defining new performance gauges
- export gauges in `analytics.__init__`
- test that analytics gauges work correctly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd3e379a8832298c665cf99780d93