### PR TITLE
Add analytics API endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, Request, responses
+from pydantic import BaseModel, Field, ValidationError, conlist, validator
+
+from analytics import generate_report
+from analytics.metrics import (
+    ANALYTICS_DRAWDOWN,
+    ANALYTICS_PNL,
+    ROLLING_PERFORMANCE_30D,
+    ROLLING_PERFORMANCE_7D,
+)
 
 from middleware.rate_limiter import RateLimiterMiddleware
-from exceptions import BaseAppError, RateLimitError
+from exceptions import (
+    AnalyticsRequestError,
+    BaseAppError,
+    RateLimitError,
+)
 from prometheus_client import generate_latest
 from logger import get_logger
 
@@ -52,4 +65,48 @@ async def exchange_status():
 async def strategy_health():
     """Simple strategy health endpoint."""
     return {"status": "running"}
+
+
+class ReportRequest(BaseModel):
+    period: str = Field(..., description="daily, weekly or monthly")
+    returns: conlist(float, min_length=1)
+
+    @validator("period")
+    def _check_period(cls, value: str) -> str:
+        if value not in {"daily", "weekly", "monthly"}:
+            raise ValueError("period must be daily, weekly or monthly")
+        return value
+
+
+@app.post("/analytics/report")
+async def analytics_report(request: Request):
+    """Generate portfolio report based on provided returns."""
+    try:
+        payload = await request.json()
+        data = ReportRequest(**payload)
+        report = generate_report(data.period, data.returns)
+        logger.info(
+            "generated report",
+            extra={"metadata": {"period": data.period}},
+        )
+        return report
+    except ValidationError as exc:
+        logger.error("report validation failed: %s", exc)
+        raise AnalyticsRequestError(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        logger.error("report failed: %s", exc)
+        raise AnalyticsRequestError(str(exc))
+
+
+@app.get("/analytics/performance")
+async def analytics_performance() -> dict[str, float]:
+    """Return current analytics performance metrics."""
+    stats = {
+        "pnl": ANALYTICS_PNL._value.get(),
+        "drawdown": ANALYTICS_DRAWDOWN._value.get(),
+        "rolling_7d": ROLLING_PERFORMANCE_7D._value.get(),
+        "rolling_30d": ROLLING_PERFORMANCE_30D._value.get(),
+    }
+    logger.info("performance stats", extra={"metadata": stats})
+    return stats
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -63,6 +63,13 @@ class ServiceUnavailableError(BaseAppError):
         super().__init__("service_unavailable", message)
 
 
+class AnalyticsRequestError(BaseAppError):
+    """Raised for invalid analytics API requests."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("analytics_error", message)
+
+
 
 
 class PriceManipulationError(BaseAppError):

--- a/tests/test_api_analytics.py
+++ b/tests/test_api_analytics.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from api import app
+from analytics.metrics import (
+    ANALYTICS_PNL,
+    ANALYTICS_DRAWDOWN,
+    ROLLING_PERFORMANCE_7D,
+    ROLLING_PERFORMANCE_30D,
+)
+
+
+client = TestClient(app)
+
+
+def test_analytics_performance_endpoint():
+    ANALYTICS_PNL.set(10.0)
+    ANALYTICS_DRAWDOWN.set(-1.0)
+    ROLLING_PERFORMANCE_7D.set(0.1)
+    ROLLING_PERFORMANCE_30D.set(0.2)
+    response = client.get("/analytics/performance")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pnl"] == 10.0
+    assert data["drawdown"] == -1.0
+    assert data["rolling_7d"] == 0.1
+    assert data["rolling_30d"] == 0.2
+
+
+def test_analytics_report_endpoint():
+    payload = {"period": "daily", "returns": [1.0, -0.5, 0.2]}
+    response = client.post("/analytics/report", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["period"] == "daily"
+    assert "total_pnl" in data
+
+
+def test_analytics_report_validation():
+    payload = {"period": "yearly", "returns": [1.0]}
+    response = client.post("/analytics/report", json=payload)
+    assert response.status_code == 503
+    data = response.json()
+    assert data["error"] == "analytics_error"


### PR DESCRIPTION
## Summary
- extend `api.py` with `/analytics` routes for reports and performance
- validate requests and reuse structured logging
- define new `AnalyticsRequestError`
- add tests for new endpoints

## Testing
- `pytest tests/test_api_analytics.py -q`
- `pytest --cov=./ tests/test_api_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd4dff0bc8322b1d832076bf16c03