### PR TITLE
Add analytics API endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 from fastapi import FastAPI, Request, responses
 
+from analytics import ReportingError, generate_report
+from exceptions import (
+    AnalyticsAPIError,
+    BaseAppError,
+    RateLimitError,
+)
+from risk_manager import RiskManager
+
 from middleware.rate_limiter import RateLimiterMiddleware
-from exceptions import BaseAppError, RateLimitError
 from prometheus_client import generate_latest
 from logger import get_logger
+
+risk_manager = RiskManager()
 
 logger = get_logger("api")
 
@@ -52,4 +61,35 @@ async def exchange_status():
 async def strategy_health():
     """Simple strategy health endpoint."""
     return {"status": "running"}
+
+
+@app.get("/analytics/report")
+async def analytics_report(period: str) -> dict:
+    """Return a P&L report for the specified period."""
+    if period not in {"daily", "weekly", "monthly"}:
+        raise AnalyticsAPIError("invalid period")
+    try:
+        report = generate_report(period, list(risk_manager.returns))
+    except ReportingError as exc:
+        logger.error("report failed: %s", exc)
+        raise AnalyticsAPIError(str(exc)) from exc
+    logger.info("report", extra={"metadata": report})
+    return report
+
+
+@app.get("/analytics/performance")
+async def analytics_performance(confidence: float = 0.95) -> dict:
+    """Return risk metrics like VaR and Sharpe ratio."""
+    if not 0 < confidence < 1:
+        raise AnalyticsAPIError("confidence must be between 0 and 1")
+    try:
+        data = {
+            "var": risk_manager.var(confidence),
+            "sharpe": risk_manager.sharpe(),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.error("performance failed: %s", exc)
+        raise AnalyticsAPIError(str(exc)) from exc
+    logger.info("performance", extra={"metadata": data})
+    return data
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -70,3 +70,10 @@ class PriceManipulationError(BaseAppError):
 
     def __init__(self, message: str) -> None:
         super().__init__("price_manipulation", message)
+
+
+class AnalyticsAPIError(BaseAppError):
+    """Raised when analytics API requests fail."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("analytics_error", message)

--- a/tests/test_api_analytics.py
+++ b/tests/test_api_analytics.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from api import app, risk_manager
+
+client = TestClient(app)
+
+
+def test_report_endpoint_valid():
+    risk_manager.returns.clear()
+    risk_manager.update_equity(0.1)
+    risk_manager.update_equity(-0.05)
+    resp = client.get("/analytics/report", params={"period": "daily"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_pnl"] != 0
+
+
+def test_report_endpoint_invalid():
+    resp = client.get("/analytics/report", params={"period": "yearly"})
+    assert resp.status_code == 503
+
+
+def test_performance_endpoint():
+    risk_manager.returns.clear()
+    for r in [0.1, -0.05, 0.2]:
+        risk_manager.update_equity(r)
+    resp = client.get("/analytics/performance", params={"confidence": 0.9})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "var" in data and "sharpe" in data
+
+
+def test_performance_invalid_confidence():
+    resp = client.get("/analytics/performance", params={"confidence": 1.5})
+    assert resp.status_code == 503
+


### PR DESCRIPTION
## Summary
- add new analytics API endpoints for report and performance stats
- introduce `AnalyticsAPIError` custom exception
- test analytics API routes

## Testing
- `pytest tests/test_api_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd97f27488322a211af862da31f24