### PR TITLE
Add advanced strategy metrics

### DIFF
--- a/strategies/base.py
+++ b/strategies/base.py
@@ -31,8 +31,12 @@ class StrategyMetrics:
     successful_trades: int = 0
     total_pnl: float = 0.0
     sharpe_ratio: float = 0.0
+    sortino_ratio: float = 0.0
+    calmar_ratio: float = 0.0
+    profit_factor: float = 0.0
     max_drawdown: float = 0.0
     win_rate: float = 0.0
+    rolling_returns: List[float] = field(default_factory=list)
 
 
 class BaseStrategy(ABC):
@@ -60,7 +64,9 @@ class BaseStrategy(ABC):
         """Analyze market conditions and return signals."""
 
     @abstractmethod
-    async def generate_signals(self, market_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    async def generate_signals(
+        self, market_data: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """Generate trading signals based on market analysis."""
 
     @abstractmethod
@@ -94,5 +100,6 @@ class BaseStrategy(ABC):
     def get_metrics(self) -> StrategyMetrics:
         """Return current strategy performance metrics."""
         return self.metrics
+
 
 __all__ = ["StrategyConfig", "StrategyMetrics", "BaseStrategy"]

--- a/tests/test_strategy_framework.py
+++ b/tests/test_strategy_framework.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from strategies.base import BaseStrategy, StrategyConfig
+from strategies.base import BaseStrategy, StrategyConfig, StrategyMetrics
 from strategies.registry import StrategyRegistry
 from strategies.arbitrage import ArbitrageStrategy
 
@@ -12,7 +12,9 @@ class DummyStrategy(BaseStrategy):
     async def analyze_market(self) -> Dict[str, Any]:
         return {}
 
-    async def generate_signals(self, market_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    async def generate_signals(
+        self, market_data: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         return []
 
     async def execute_trades(self, signals: List[Dict[str, Any]]) -> List[str]:
@@ -23,7 +25,9 @@ class DummyStrategy(BaseStrategy):
 async def test_registry_create_strategy():
     registry = StrategyRegistry()
     registry.register("dummy", DummyStrategy)
-    strat = registry.create_strategy("dummy", router=None, config=StrategyConfig(name="dummy"))
+    strat = registry.create_strategy(
+        "dummy", router=None, config=StrategyConfig(name="dummy")
+    )
     assert isinstance(strat, DummyStrategy)
     assert "dummy" in registry.list_strategies()
 
@@ -35,3 +39,11 @@ async def test_arbitrage_run_cycle(monkeypatch):
     strategy = ArbitrageStrategy(router)
     await strategy.run_cycle()
     assert strategy.metrics.total_trades >= 0
+
+
+def test_strategy_metrics_defaults():
+    metrics = StrategyMetrics()
+    assert metrics.sortino_ratio == 0.0
+    assert metrics.calmar_ratio == 0.0
+    assert metrics.profit_factor == 0.0
+    assert metrics.rolling_returns == []


### PR DESCRIPTION
## Summary
- expand `StrategyMetrics` with Sortino ratio, Calmar ratio, profit factor, and rolling returns
- test new metric defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cdc58766883229986c1e51004c3e2