### PR TITLE
Fix import order issues for ruff E402

### DIFF
--- a/cross_chain/__init__.py
+++ b/cross_chain/__init__.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Cross-chain bridge interfaces."""
+
+from __future__ import annotations
 
 from abc import ABC
 

--- a/cross_chain/bridge_provider.py
+++ b/cross_chain/bridge_provider.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Bridge price providers for cross-chain arbitrage."""
+
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 

--- a/flash_loans/__init__.py
+++ b/flash_loans/__init__.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Flash loan utilities and providers."""
+
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Awaitable, Callable

--- a/flash_loans/arbitrage.py
+++ b/flash_loans/arbitrage.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Flash loan based arbitrage executor."""
+
+from __future__ import annotations
 
 import asyncio
 from typing import Awaitable, Callable

--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 """Profit optimization utilities.
 
 This module provides several linear programming optimizers that use
 `pulp` to determine optimal capital allocations under different models.
 Each optimizer records metrics on successful and failed optimization runs.
 """
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List

--- a/strategies/arbitrage_engine.py
+++ b/strategies/arbitrage_engine.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Advanced arbitrage engine handling multiple arbitrage types."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Abstract strategy classes and metrics."""
+
+from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod

--- a/utils/circuit_breaker.py
+++ b/utils/circuit_breaker.py
@@ -8,9 +8,9 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from logger import get_logger
+from exceptions import ServiceUnavailableError
 
 logger = get_logger("circuit_breaker")
-from exceptions import ServiceUnavailableError
 
 
 class CircuitBreaker:


### PR DESCRIPTION
## Summary
- move module docstrings above imports in cross-chain, flash-loan, optimization, and strategy modules
- fix utility import order
- verify `ruff check` passes without E402 errors

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pulp', 'httpx', 'fastapi', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ce0a0dc4c8322a9c1f3fb2d1f5664