### PR TITLE
Add analytics section and module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ The project includes a small FastAPI application exposing `/health` and `/ready`
 endpoints with request rate limiting. DEX interactions are guarded by a circuit
 breaker and all blockchain calls use exponential backoff to handle transient
 failures.
+## Analytics
+
+Real-time P&L tracking captures every trade and updates asset prices as they arrive. The reporting module aggregates these metrics to generate periodic summaries including total returns, averages, and drawdowns. Reports can be exported to JSON or CSV for dashboards or further analysis.
+
 
 🧩 How to Extend the Bot
 The modular design makes it easy to add new strategies. To create your own:

--- a/analytics/engine.py
+++ b/analytics/engine.py
@@ -1,3 +1,4 @@
+"""Core analytics engine for computing real-time P&L and risk metrics for trading strategies."""
 from __future__ import annotations
 
 import os

--- a/analytics/reporting.py
+++ b/analytics/reporting.py
@@ -1,3 +1,4 @@
+"""Functions for generating aggregated reports and exporting results."""
 from __future__ import annotations
 
 import asyncio

--- a/analytics/visualization.py
+++ b/analytics/visualization.py
@@ -1,3 +1,4 @@
+"""Utility helpers to build P&L and drawdown curves for dashboards."""
 from __future__ import annotations
 
 from typing import Dict, List


### PR DESCRIPTION
## Summary
- document real-time P&L tracking in README
- add module docstrings for analytics modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce19518e8832281a69f766b6befab