### PR TITLE
Add database subpackages for ORM and services

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,23 @@
+"""Database package exports."""
+
+from .models import (
+    Base,
+    TimestampedModel,
+    TradeExecution,
+    StrategyPerformance,
+    MarketDataCache,
+)
+from .repositories import BaseRepository, TradeRepository
+from .services import DatabaseService
+
+__all__ = [
+    "Base",
+    "TimestampedModel",
+    "TradeExecution",
+    "StrategyPerformance",
+    "MarketDataCache",
+    "BaseRepository",
+    "TradeRepository",
+    "DatabaseService",
+]
+

--- a/database/models/__init__.py
+++ b/database/models/__init__.py
@@ -1,110 +1,72 @@
-from __future__ import annotations
+"""Database ORM models export."""
+
+from .base import Base, TimestampedModel
+from .trading import MarketDataCache, StrategyPerformance, TradeExecution
 
 from datetime import datetime
-from typing import Any
 
-from sqlalchemy import DateTime, Float, Integer, MetaData, String, func
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-
-
-class Base(DeclarativeBase):
-    metadata = MetaData(
-        naming_convention={
-            "ix": "ix_%(column_0_label)s",
-            "uq": "uq_%(table_name)s_%(column_0_name)s",
-            "ck": "ck_%(table_name)s_%(constraint_name)s",
-            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-            "pk": "pk_%(table_name)s",
-        }
-    )
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 
-class TradeExecution(Base):
-    __tablename__ = "trade_execution"
+class ConfigurationVersion(TimestampedModel, Base):
+    """Track configuration versions."""
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    strategy: Mapped[str] = mapped_column(String(50), index=True)
-    token_pair: Mapped[str] = mapped_column(String(50))
-    amount: Mapped[float] = mapped_column(Float)
-    price: Mapped[float] = mapped_column(Float)
-    tx_hash: Mapped[str] = mapped_column(String(66), unique=True)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
-
-
-class StrategyPerformance(Base):
-    __tablename__ = "strategy_performance"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    strategy: Mapped[str] = mapped_column(String(50), index=True)
-    metric: Mapped[str] = mapped_column(String(50))
-    value: Mapped[float] = mapped_column(Float)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
-
-
-class MarketDataCache(Base):
-    __tablename__ = "market_data_cache"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    token_pair: Mapped[str] = mapped_column(String(50), index=True)
-    data: Mapped[Any] = mapped_column(String)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
-
-
-class ConfigurationVersion(Base):
     __tablename__ = "configuration_version"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     version: Mapped[str] = mapped_column(String(50), unique=True)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
 
 
-class UserSession(Base):
+class UserSession(TimestampedModel, Base):
+    """Session information for platform users."""
+
     __tablename__ = "user_session"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     session_id: Mapped[str] = mapped_column(String(64), unique=True)
-    started_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
-class AuditLog(Base):
+class AuditLog(TimestampedModel, Base):
+    """Record user and system actions."""
+
     __tablename__ = "audit_log"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     action: Mapped[str] = mapped_column(String(100))
     context: Mapped[str] = mapped_column(String)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
 
 
-class PortfolioSnapshot(Base):
+class PortfolioSnapshot(TimestampedModel, Base):
+    """Snapshot of current portfolio state."""
+
     __tablename__ = "portfolio_snapshot"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     data: Mapped[str] = mapped_column(String)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
 
 
-class RiskEvent(Base):
+class RiskEvent(TimestampedModel, Base):
+    """Risk-related events for auditing."""
+
     __tablename__ = "risk_event"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     event_type: Mapped[str] = mapped_column(String(50))
     description: Mapped[str] = mapped_column(String)
-    timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+
+
+__all__ = [
+    "Base",
+    "TimestampedModel",
+    "TradeExecution",
+    "StrategyPerformance",
+    "MarketDataCache",
+    "ConfigurationVersion",
+    "UserSession",
+    "AuditLog",
+    "PortfolioSnapshot",
+    "RiskEvent",
+]
 

--- a/database/models/base.py
+++ b/database/models/base.py
@@ -1,0 +1,33 @@
+"""Base ORM declarations for database models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, MetaData, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Declarative base class with naming convention."""
+
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
+
+
+class TimestampedModel:
+    """Mixin providing creation and update timestamps."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now()
+    )

--- a/database/models/trading.py
+++ b/database/models/trading.py
@@ -1,0 +1,44 @@
+"""Trading related ORM models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import Float, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base, TimestampedModel
+
+
+class TradeExecution(TimestampedModel, Base):
+    """Executed trade information."""
+
+    __tablename__ = "trade_execution"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    strategy: Mapped[str] = mapped_column(String(50), index=True)
+    token_pair: Mapped[str] = mapped_column(String(50))
+    amount: Mapped[float] = mapped_column(Float)
+    price: Mapped[float] = mapped_column(Float)
+    tx_hash: Mapped[str] = mapped_column(String(66), unique=True)
+
+
+class StrategyPerformance(TimestampedModel, Base):
+    """Performance metrics for a trading strategy."""
+
+    __tablename__ = "strategy_performance"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    strategy: Mapped[str] = mapped_column(String(50), index=True)
+    metric: Mapped[str] = mapped_column(String(50))
+    value: Mapped[float] = mapped_column(Float)
+
+
+class MarketDataCache(TimestampedModel, Base):
+    """Cached market data for token pairs."""
+
+    __tablename__ = "market_data_cache"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    token_pair: Mapped[str] = mapped_column(String(50), index=True)
+    data: Mapped[Any] = mapped_column(String)

--- a/database/repositories/__init__.py
+++ b/database/repositories/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseRepository
+from .trade import TradeRepository
+

--- a/database/repositories/base.py
+++ b/database/repositories/base.py
@@ -1,0 +1,13 @@
+"""Base repository providing session access."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class BaseRepository:
+    """Common repository utilities."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+

--- a/database/repositories/trade.py
+++ b/database/repositories/trade.py
@@ -1,3 +1,5 @@
+"""Repository for trade execution models."""
+
 from __future__ import annotations
 
 from typing import List
@@ -6,13 +8,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import TradeExecution
+from .base import BaseRepository
 
 
-class TradeRepository:
-    """Repository for trade execution data."""
-
-    def __init__(self, session: AsyncSession) -> None:
-        self._session = session
+class TradeRepository(BaseRepository):
+    """Operations for persisting and querying trades."""
 
     async def record_trade(self, trade: TradeExecution) -> None:
         self._session.add(trade)
@@ -20,6 +20,6 @@ class TradeRepository:
 
     async def get_strategy_trades(self, strategy: str) -> List[TradeExecution]:
         stmt = select(TradeExecution).where(TradeExecution.strategy == strategy)
-        res = await self._session.execute(stmt)
-        return list(res.scalars())
+        result = await self._session.execute(stmt)
+        return list(result.scalars())
 

--- a/database/scripts/backup.py
+++ b/database/scripts/backup.py
@@ -1,0 +1,4 @@
+"""Database backup utilities."""
+
+# TODO: implement backup logic
+

--- a/database/scripts/maintenance.py
+++ b/database/scripts/maintenance.py
@@ -1,0 +1,4 @@
+"""Routine database maintenance tasks."""
+
+# TODO: implement maintenance tasks
+

--- a/database/services/__init__.py
+++ b/database/services/__init__.py
@@ -1,0 +1,1 @@
+from .database import DatabaseService

--- a/database/services/database.py
+++ b/database/services/database.py
@@ -1,3 +1,5 @@
+"""High level async database access service."""
+
 from __future__ import annotations
 
 from contextlib import asynccontextmanager

--- a/tests/test_database_service.py
+++ b/tests/test_database_service.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from database.service import DatabaseService
+from database.services import DatabaseService
 from sqlalchemy.ext.asyncio import create_async_engine
 from config import CONFIG_MANAGER, DatabaseSettings
 
@@ -13,7 +13,9 @@ async def test_get_session(monkeypatch):
     def fake_engine(url: str, **kwargs: Any):
         return create_async_engine("sqlite+aiosqlite:///:memory:")
 
-    monkeypatch.setattr("database.service.create_async_engine", fake_engine)
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine", fake_engine
+    )
     settings = DatabaseSettings(
         url="postgresql+asyncpg://user:pass@localhost/test"
     )
@@ -23,7 +25,7 @@ async def test_get_session(monkeypatch):
 
 
 from database.models import Base, TradeExecution
-from database.repositories.trade_repository import TradeRepository
+from database.repositories import TradeRepository
 
 
 @pytest.mark.asyncio
@@ -31,7 +33,9 @@ async def test_trade_repository_record_and_get(monkeypatch):
     def fake_engine(url: str, **kwargs: Any):
         return create_async_engine("sqlite+aiosqlite:///:memory:")
 
-    monkeypatch.setattr("database.service.create_async_engine", fake_engine)
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine", fake_engine
+    )
     settings = DatabaseSettings(
         url="postgresql+asyncpg://user:pass@localhost/test"
     )


### PR DESCRIPTION
## Summary
- break out ORM base and trading models
- implement database service and repository subpackages
- clean up existing modules and tests
- add migrations and scripts placeholders

## Testing
- `pytest tests/test_database_service.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d68219c8c83229f96ada67ab431fd