### PR TITLE
Add DB session context manager and metrics

### DIFF
--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -24,6 +24,20 @@ RISK_ADJUSTED_PROFIT = Histogram(
 )
 PORTFOLIO_VALUE = Gauge('portfolio_value', 'Total portfolio value')
 REBALANCE_COUNT = Counter('portfolio_rebalance_total', 'Number of portfolio rebalances')
+
+# Database metrics
+DB_HEALTH_CHECKS = Counter(
+    'db_health_checks_total',
+    'Total number of database health checks',
+)
+DB_HEALTH_FAILURES = Counter(
+    'db_health_failures_total',
+    'Number of failed database health checks',
+)
+DB_ACTIVE_CONNECTIONS = Gauge(
+    'db_active_connections',
+    'Currently active database connections',
+)
 __all__ = [
     'TRADE_COUNT',
     'TRADE_SUCCESS',
@@ -36,4 +50,7 @@ __all__ = [
     'RISK_ADJUSTED_PROFIT',
     'PORTFOLIO_VALUE',
     'REBALANCE_COUNT',
+    'DB_HEALTH_CHECKS',
+    'DB_HEALTH_FAILURES',
+    'DB_ACTIVE_CONNECTIONS',
 ]


### PR DESCRIPTION
## Summary
- switch `DatabaseService.get_session` to be an async context manager
- update `transaction` to use the new context manager
- track database health and active sessions with Prometheus metrics
- test metrics and new context manager behaviour

## Testing
- `pytest tests/test_database_service.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6b0d2398832298602dd4b815eba0