### PR TITLE
Add async DB backup and maintenance scripts

### DIFF
--- a/database/scripts/__init__.py
+++ b/database/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Database utility scripts package."""

--- a/database/scripts/backup.py
+++ b/database/scripts/backup.py
@@ -1,4 +1,66 @@
-"""Database backup utilities."""
+"""Async database backup utilities."""
 
-# TODO: implement backup logic
+from __future__ import annotations
 
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from urllib.parse import urlparse
+
+from logger import get_logger
+from utils.retry import retry_async
+from exceptions import ConfigurationError, DatabaseBackupError
+
+logger = get_logger("db_backup")
+
+
+def _parse_pg_url(url: str) -> str:
+    parsed = urlparse(url.replace("+asyncpg", ""))
+    if not parsed.scheme or not parsed.path or not parsed.hostname:
+        raise ConfigurationError("Invalid DATABASE__URL")
+    pwd = f":{parsed.password}" if parsed.password else ""
+    port = f":{parsed.port}" if parsed.port else ""
+    db = parsed.path.lstrip("/")
+    user = parsed.username or ""
+    return f"postgresql://{user}{pwd}@{parsed.hostname}{port}/{db}"
+
+
+async def _exec_pg_dump(dsn: str, path: Path, timeout: int) -> None:
+    env = os.environ.copy()
+    env.setdefault("PGPASSWORD", urlparse(dsn).password or "")
+    process = await asyncio.create_subprocess_exec(
+        "pg_dump", "--dbname", dsn, "--file", str(path), env=env
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout)
+    if process.returncode != 0:
+        logger.error("pg_dump failed: %s", stderr.decode())
+        raise DatabaseBackupError("pg_dump failed")
+    if stdout:
+        logger.info("pg_dump: %s", stdout.decode().strip())
+
+
+async def encrypt_backup(path: Path) -> Path:
+    """Encrypt the backup file (stub)."""
+    if not path.exists():
+        raise DatabaseBackupError("backup file missing")
+    dest = path.with_suffix(path.suffix + ".enc")
+    await asyncio.to_thread(shutil.copyfile, path, dest)
+    return dest
+
+
+async def run_backup(output_path: str, timeout: int = 60) -> Path:
+    """Run pg_dump and encrypt the output."""
+    if not output_path:
+        raise ValueError("output_path required")
+    url = os.getenv("DATABASE__URL")
+    if not url:
+        raise ConfigurationError("DATABASE__URL missing")
+    dsn = _parse_pg_url(url)
+    path = Path(output_path)
+
+    async def _dump() -> None:
+        await _exec_pg_dump(dsn, path, timeout)
+
+    await retry_async(_dump)
+    return await encrypt_backup(path)

--- a/database/scripts/maintenance.py
+++ b/database/scripts/maintenance.py
@@ -1,4 +1,54 @@
 """Routine database maintenance tasks."""
 
-# TODO: implement maintenance tasks
+from __future__ import annotations
 
+import os
+from typing import Iterable
+
+import asyncpg
+
+from logger import get_logger
+from utils.retry import retry_async
+from exceptions import ConfigurationError, DatabaseMaintenanceError
+
+logger = get_logger("db_maint")
+
+
+def _pg_dsn() -> str:
+    url = os.getenv("DATABASE__URL")
+    if not url:
+        raise ConfigurationError("DATABASE__URL missing")
+    return url.replace("+asyncpg", "")
+
+
+async def _exec(query: str) -> None:
+    conn_str = _pg_dsn()
+    async with asyncpg.connect(conn_str) as conn:
+        await conn.execute(query)
+
+
+async def vacuum_analyze() -> None:
+    """Run VACUUM ANALYZE."""
+    async def _run() -> None:
+        await _exec("VACUUM (ANALYZE)")
+
+    await retry_async(_run)
+
+
+async def check_indexes() -> list[str]:
+    """Return names of indexes not ready."""
+    async def _run() -> Iterable[str]:
+        conn_str = _pg_dsn()
+        async with asyncpg.connect(conn_str) as conn:
+            rows = await conn.fetch(
+                "SELECT indexrelid::regclass::text AS name FROM pg_index "
+                "WHERE NOT indisready"
+            )
+            return [r["name"] for r in rows]
+
+    try:
+        result = await retry_async(_run)
+        return list(result)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Index check failed: %s", exc)
+        raise DatabaseMaintenanceError("index check failed") from exc

--- a/exceptions.py
+++ b/exceptions.py
@@ -84,3 +84,17 @@ class AnalyticsAPIError(BaseAppError):
 
     def __init__(self, message: str) -> None:
         super().__init__("analytics_error", message)
+
+
+class DatabaseBackupError(BaseAppError):
+    """Raised when database backup fails."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("db_backup_error", message)
+
+
+class DatabaseMaintenanceError(BaseAppError):
+    """Raised when maintenance operations fail."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__("db_maintenance_error", message)

--- a/tests/test_db_scripts.py
+++ b/tests/test_db_scripts.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from database.scripts import backup, maintenance
+from exceptions import ConfigurationError
+
+
+@pytest.mark.asyncio
+async def test_run_backup(monkeypatch, tmp_path):
+    out = tmp_path / "db.sql"
+
+    async def fake_exec(dsn: str, path: Path, timeout: int) -> None:
+        path.write_text("content")
+
+    monkeypatch.setattr(backup, "_exec_pg_dump", fake_exec)
+    enc = await backup.run_backup(str(out))
+    assert enc.exists()
+    assert enc.suffix == ".enc"
+
+
+@pytest.mark.asyncio
+async def test_run_backup_missing_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("DATABASE__URL", raising=False)
+    with pytest.raises(ConfigurationError):
+        await backup.run_backup(str(tmp_path / "out.sql"))
+
+
+@pytest.mark.asyncio
+async def test_vacuum_and_index(monkeypatch):
+    executed: list[str] = []
+
+    class Conn:
+        async def execute(self, query: str) -> None:
+            executed.append(query)
+
+        async def fetch(self, query: str):
+            return [dict(name="idx")]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_connect(_):
+        return Conn()
+
+    monkeypatch.setattr(
+        maintenance,
+        "asyncpg",
+        SimpleNamespace(connect=fake_connect),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "retry_async",
+        lambda func, *a, **k: func(*a, **k),
+    )
+
+    await maintenance.vacuum_analyze()
+    assert executed == ["VACUUM (ANALYZE)"]
+    res = await maintenance.check_indexes()
+    assert res == ["idx"]


### PR DESCRIPTION
## Summary
- implement async pg_dump backup and encryption stub
- add routine maintenance tasks for vacuum and index checks
- extend exceptions with backup & maintenance errors
- package database scripts for importing
- create tests for backup and maintenance utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d703950408322b2b460cc72ddfaea