### PR TITLE
Secure export path validation

### DIFF
--- a/tests/test_reporting_visualization.py
+++ b/tests/test_reporting_visualization.py
@@ -28,7 +28,8 @@ def test_prepare_visualization():
 
 
 @pytest.mark.asyncio
-async def test_report_export(tmp_path):
+async def test_report_export(tmp_path, monkeypatch):
+    monkeypatch.setenv("EXPORT_DIR", str(tmp_path))
     returns = [0.1] * 10
     report = generate_report("daily", returns)
     json_path = tmp_path / "r.json"


### PR DESCRIPTION
## Summary
- validate export paths in `analytics/reporting.py`
- test path validation for report exports
- adapt visualization tests for new environment variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d73332aac8322b268eade84691e92