### PR TITLE
Improve HttpBridgeProvider retry logic

### DIFF
--- a/tests/test_bridge_provider.py
+++ b/tests/test_bridge_provider.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock
+import httpx
 from exceptions import ServiceUnavailableError
 
 from cross_chain.bridge_provider import HttpBridgeProvider, BridgeProviderError
@@ -15,7 +16,7 @@ class DummyClient:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
-    async def get(self, url):
+    async def get(self, url, timeout=10):
         return self
 
     def raise_for_status(self):
@@ -27,15 +28,12 @@ class DummyClient:
 
 @pytest.mark.asyncio
 async def test_get_price(monkeypatch):
-    monkeypatch.setattr(
-        "httpx.AsyncClient",
-        lambda timeout=10: DummyClient({"price": 5.0}),
-    )
+    client_factory = lambda: DummyClient({"price": 5.0})
+    monkeypatch.setattr("httpx.AsyncClient", client_factory)
     provider = HttpBridgeProvider("http://api")
     provider._circuit.call = lambda func, *a, **kw: func(*a, **kw)
-    monkeypatch.setattr(
-        "utils.retry.retry_async", lambda func, *a, **kw: func(*a, **kw)
-    )
+    patch_retry = lambda func, *a, **kw: func(*a, **kw)
+    monkeypatch.setattr("utils.retry.retry_async", patch_retry)
     price = await provider.get_price("token", "chain")
     assert price == 5.0
 
@@ -43,17 +41,47 @@ async def test_get_price(monkeypatch):
 @pytest.mark.asyncio
 async def test_get_price_error(monkeypatch):
     class FailClient(DummyClient):
-        async def get(self, url):
-            raise RuntimeError("fail")
+        async def get(self, url, timeout=10):
+            raise httpx.RequestError("fail", request=httpx.Request("GET", url))
 
-    monkeypatch.setattr("httpx.AsyncClient", lambda timeout=10: FailClient({}))
+    monkeypatch.setattr("httpx.AsyncClient", lambda: FailClient({}))
     provider = HttpBridgeProvider("http://api")
     provider._circuit.call = lambda func, *a, **kw: func(*a, **kw)
-    monkeypatch.setattr(
-        "utils.retry.retry_async", lambda func, *a, **kw: func(*a, **kw)
-    )
+    patch_retry = lambda func, *a, **kw: func(*a, **kw)
+    monkeypatch.setattr("utils.retry.retry_async", patch_retry)
     with pytest.raises(BridgeProviderError):
         await provider.get_price("token", "chain")
+
+
+@pytest.mark.asyncio
+async def test_get_price_transient_failure(monkeypatch):
+    class FlakyClient(DummyClient):
+        def __init__(self) -> None:
+            super().__init__({"price": 7.0})
+            self.calls = 0
+
+        async def get(self, url, timeout=10):
+            if self.calls == 0:
+                self.calls += 1
+                raise httpx.RequestError(
+                    "fail", request=httpx.Request("GET", url)
+                )
+            return self
+
+    async def fake_retry(func, *args, retries=3, **kwargs):
+        for attempt in range(retries):
+            try:
+                return await func(*args, **kwargs)
+            except Exception:
+                if attempt == retries - 1:
+                    raise
+
+    monkeypatch.setattr("httpx.AsyncClient", lambda: FlakyClient())
+    monkeypatch.setattr("utils.retry.retry_async", fake_retry)
+    provider = HttpBridgeProvider("http://api")
+    provider._circuit.call = lambda func, *a, **kw: func(*a, **kw)
+    price = await provider.get_price("token", "chain")
+    assert price == 7.0
 
 
 @pytest.mark.asyncio
@@ -62,5 +90,27 @@ async def test_get_price_circuit_open(monkeypatch):
     provider._circuit.call = AsyncMock(
         side_effect=ServiceUnavailableError("open")
     )
+    with pytest.raises(BridgeProviderError):
+        await provider.get_price("token", "chain")
+
+
+@pytest.mark.asyncio
+async def test_get_price_request_error(monkeypatch):
+    class FailingClient(DummyClient):
+        async def get(self, url, timeout=10):
+            raise httpx.RequestError("boom", request=httpx.Request("GET", url))
+
+    async def fake_retry(func, *args, retries=3, **kwargs):
+        for attempt in range(retries):
+            try:
+                return await func(*args, **kwargs)
+            except Exception:
+                if attempt == retries - 1:
+                    raise
+
+    monkeypatch.setattr("httpx.AsyncClient", lambda: FailingClient({}))
+    monkeypatch.setattr("utils.retry.retry_async", fake_retry)
+    provider = HttpBridgeProvider("http://api")
+    provider._circuit.call = lambda func, *a, **kw: func(*a, **kw)
     with pytest.raises(BridgeProviderError):
         await provider.get_price("token", "chain")


### PR DESCRIPTION
## Summary
- retry HTTP get with explicit retries and timeout
- raise `BridgeProviderError` for `httpx.RequestError`
- test retry logic on transient failures

## Testing
- `pytest -q tests/test_bridge_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_684d74675f088322bc8d585a907c95a8