### PR TITLE
Add repository and DB service tests

### DIFF
--- a/tests/test_base_repository.py
+++ b/tests/test_base_repository.py
@@ -1,0 +1,49 @@
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import String
+
+from database.models import Base
+from database.repositories.base import BaseRepository
+
+
+class Item(Base):
+    __tablename__ = "item"
+    name: Mapped[str] = mapped_column(String(50))
+
+
+class ItemRepository(BaseRepository):
+    async def add(self, item: Item) -> None:
+        self._session.add(item)
+        await self._session.commit()
+
+    async def get(self, item_id) -> Item | None:
+        return await self._session.get(Item, item_id)
+
+    async def update_name(self, item: Item, name: str) -> None:
+        item.name = name
+        await self._session.commit()
+
+    async def delete(self, item: Item) -> None:
+        await self._session.delete(item)
+        await self._session.commit()
+
+
+@pytest.mark.asyncio
+async def test_item_repository_crud() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with session_maker() as session:
+        repo = ItemRepository(session)
+        item = Item(name="foo")
+        await repo.add(item)
+        fetched = await repo.get(item.id)
+        assert fetched is not None and fetched.name == "foo"
+        await repo.update_name(fetched, "bar")
+        assert (await repo.get(item.id)).name == "bar"
+        await repo.delete(fetched)
+        assert await repo.get(item.id) is None
+
+

--- a/tests/test_database_service_context.py
+++ b/tests/test_database_service_context.py
@@ -1,0 +1,49 @@
+import pytest
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy.ext.asyncio import create_async_engine
+from observability.metrics import DB_HEALTH_FAILURES
+
+from exceptions import ServiceUnavailableError
+from database.services import DatabaseService
+from config import DatabaseSettings
+from database.models import Base
+
+
+class DummyFailSession:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def execute(self, *args: Any, **kwargs: Any):
+        raise RuntimeError("boom")
+
+    async def rollback(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_get_session_failure(monkeypatch) -> None:
+    def fake_engine(url: str, **kwargs: Any):
+        return create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine",
+        fake_engine,
+    )
+    service = DatabaseService(
+        DatabaseSettings(url="postgresql+asyncpg://user:pass@localhost/test")
+    )
+    dummy = DummyFailSession()
+    service._sessionmaker = lambda: dummy
+    service._circuit = SimpleNamespace(call=lambda f, *a, **k: f(*a, **k))
+    failures_before = DB_HEALTH_FAILURES._value.get()
+    with pytest.raises(ServiceUnavailableError):
+        async with service.get_session():
+            pass
+    assert dummy.closed
+    assert DB_HEALTH_FAILURES._value.get() == failures_before + 1


### PR DESCRIPTION
## Summary
- add CRUD tests for BaseRepository using in-memory DB
- cover DatabaseService failure handling

## Testing
- `pytest tests/test_database_service_context.py tests/test_base_repository.py tests/test_redis_cache.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d76050da88322af49ee75c601920a