### PR TITLE
Integrate slippage protection into DEX handler

### DIFF
--- a/tests/test_custom_exceptions.py
+++ b/tests/test_custom_exceptions.py
@@ -14,6 +14,7 @@ import pytest
 
 from exceptions import DexError, StrategyError
 from dex_handler import DEXHandler
+from slippage_protection import SlippageProtectionEngine
 from web3_service import TransactionFailedError
 from routing import Router
 from strategy import ArbitrageStrategy
@@ -24,13 +25,31 @@ def test_strategy_initializes_without_error():
     assert isinstance(ArbitrageStrategy(router), ArbitrageStrategy)
 
 
-def test_execute_swap_raises_dex_error():
+def test_execute_swap_raises_dex_error(monkeypatch):
     handler = DEXHandler.__new__(DEXHandler)
     handler.web3_service = MagicMock()
     handler.contract = MagicMock()
     handler.web3_service.account = MagicMock(address="0xabc")
     handler.web3_service.web3 = MagicMock(eth=MagicMock(gas_price=1))
     handler._circuit = MagicMock(call=lambda f, *a, **kw: f(*a, **kw))
+
+    handler.contract.functions.getAmountsOut = MagicMock(
+        return_value=MagicMock(call=MagicMock(return_value=[1, 2]))
+    )
+    async def fake_thread(func, *a, **kw):
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_thread)
+    monkeypatch.setattr(
+        SlippageProtectionEngine,
+        "calculate_protected_slippage",
+        lambda amt: 1,
+    )
+    monkeypatch.setattr(
+        SlippageProtectionEngine,
+        "validate_transaction_slippage",
+        lambda *a, **kw: None,
+    )
 
     built_tx = {"tx": 1}
     swap_func = MagicMock(return_value=MagicMock(build_transaction=MagicMock(return_value=built_tx)))

--- a/tests/test_slippage_protection.py
+++ b/tests/test_slippage_protection.py
@@ -1,6 +1,7 @@
 import pytest
 
 import slippage_protection
+import config
 
 from exceptions import PriceManipulationError
 from slippage_protection import (
@@ -84,3 +85,13 @@ def test_analyze_market_conditions_classification():
 
 def test_calculate_dynamic_slippage():
     assert calculate_dynamic_slippage(0.1, 0.2) == 0.1 * 1.2
+
+
+def test_calculate_protected_slippage_and_validation(monkeypatch):
+    monkeypatch.setattr(config, "MAX_SLIPPAGE_BPS", 50)
+    expected = 1000
+    min_out = SlippageProtectionEngine.calculate_protected_slippage(expected)
+    assert min_out == 995
+    SlippageProtectionEngine.validate_transaction_slippage(expected, min_out)
+    with pytest.raises(PriceManipulationError):
+        SlippageProtectionEngine.validate_transaction_slippage(expected, 900)


### PR DESCRIPTION
## Summary
- add functions for calculating and validating slippage
- integrate slippage protection with `DEXHandler`
- adjust async tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df357fcbc8322a29276507ec1ac4f