### PR TITLE
Add secure DB keys to configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,3 +52,13 @@ os.environ.setdefault("DATABASE__MAX_OVERFLOW", "10")
 os.environ.setdefault("DATABASE__POOL_TIMEOUT", "30")
 os.environ.setdefault("DATABASE__POOL_RECYCLE", "3600")
 os.environ.setdefault("DATABASE__ECHO", "false")
+os.environ.setdefault("DATABASE__REQUIRE_SSL", "true")
+os.environ.setdefault(
+    "DATABASE__ENCRYPTION_KEY",
+    "8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+)
+os.environ.setdefault(
+    "DATABASE__AUDIT_ENCRYPTION_KEY",
+    "oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+)
+os.environ.setdefault("DATABASE__QUERY_TIMEOUT", "30")

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,7 +1,19 @@
+import pytest
 from config import CONFIG_MANAGER
+from exceptions import ConfigurationError
 
 
 def test_database_settings_loaded():
     cfg = CONFIG_MANAGER.config.database
     assert str(cfg.url).startswith("postgresql")
     assert cfg.pool_size == 5
+    assert cfg.require_ssl is True
+    assert len(cfg.encryption_key) == 44
+    assert len(cfg.audit_encryption_key) == 44
+    assert cfg.query_timeout == 30
+
+
+def test_invalid_encryption_key(monkeypatch):
+    monkeypatch.setenv("DATABASE__ENCRYPTION_KEY", "x" * 44)
+    with pytest.raises(ConfigurationError):
+        CONFIG_MANAGER.reload()

--- a/tests/test_database_service.py
+++ b/tests/test_database_service.py
@@ -22,7 +22,10 @@ async def test_get_session(monkeypatch):
         "database.services.database.create_async_engine", fake_engine
     )
     settings = DatabaseSettings(
-        url="postgresql+asyncpg://user:pass@localhost/test"
+        url="postgresql+asyncpg://user:pass@localhost/test",
+        encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+        audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+        query_timeout=30,
     )
     service = DatabaseService(settings)
     start_checks = DB_HEALTH_CHECKS._value.get()
@@ -47,7 +50,10 @@ async def test_trade_repository_record_and_get(monkeypatch):
         "database.services.database.create_async_engine", fake_engine
     )
     settings = DatabaseSettings(
-        url="postgresql+asyncpg://user:pass@localhost/test"
+        url="postgresql+asyncpg://user:pass@localhost/test",
+        encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+        audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+        query_timeout=30,
     )
     service = DatabaseService(settings)
     async with service.transaction() as session:

--- a/tests/test_database_service_context.py
+++ b/tests/test_database_service_context.py
@@ -36,7 +36,12 @@ async def test_get_session_failure(monkeypatch) -> None:
         fake_engine,
     )
     service = DatabaseService(
-        DatabaseSettings(url="postgresql+asyncpg://user:pass@localhost/test")
+        DatabaseSettings(
+            url="postgresql+asyncpg://user:pass@localhost/test",
+            encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+            audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+            query_timeout=30,
+        )
     )
     dummy = DummyFailSession()
     service._sessionmaker = lambda: dummy


### PR DESCRIPTION
## Summary
- extend `DatabaseSettings` with SSL, encryption keys and timeout
- validate encryption keys are Fernet strings
- expose new DB settings as globals
- update environment defaults for tests
- test configuration for new DB fields

## Testing
- `pytest tests/test_database_config.py::test_database_settings_loaded -q`
- `pytest tests/test_database_config.py::test_invalid_encryption_key -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1946f5808322819bf9be799bab2b