### PR TITLE
Implement secure async Web3 service

### DIFF
--- a/async_web3_service.py
+++ b/async_web3_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Asynchronous Web3 service with secure key handling."""
+
+import asyncio
+import random
+from typing import Any, Dict, List
+
+from eth_account import Account
+from web3 import AsyncHTTPProvider, AsyncWeb3
+from web3.exceptions import TimeExhausted
+from web3.middleware import proof_of_authority
+from web3.middleware.signing import SignAndSendRawMiddlewareBuilder
+from web3.types import TxParams, TxReceipt
+
+from logger import get_logger
+from security import SecureKeyManager, secure_zero_memory
+
+logger = get_logger("async_web3_service")
+
+
+class TransactionFailedError(Exception):
+    """Custom exception for failed on-chain transactions."""
+
+
+class TransactionTimeoutError(Exception):
+    """Raised when a transaction does not get mined in time."""
+
+
+class AsyncWeb3Service:
+    """Handle async Ethereum interactions with secure key management."""
+
+    def __init__(self, web3: AsyncWeb3, account: Account) -> None:
+        self.web3 = web3
+        self.account = account
+        self.web3.eth.default_account = account.address
+
+    @classmethod
+    async def create(cls, rpc_url: str, encrypted_private_key: str) -> "AsyncWeb3Service":
+        web3 = AsyncWeb3(AsyncHTTPProvider(rpc_url))
+        web3.middleware_onion.inject(proof_of_authority.ExtraDataToPOAMiddleware, layer=0)
+        if not await web3.is_connected():
+            raise ConnectionError("Failed to connect to Ethereum node.")
+        key_manager = SecureKeyManager()
+        key = key_manager.decrypt_private_key(encrypted_private_key)
+        try:
+            account = Account.from_key(key)
+        finally:
+            secure_zero_memory(bytearray(key, "utf-8"))
+        middleware = SignAndSendRawMiddlewareBuilder.build(account, web3)
+        web3.middleware_onion.add(middleware.async_wrap_make_request, name="sign_send")
+        return cls(web3, account)
+
+    async def get_contract(self, address: str, abi: List[Dict[str, Any]]):
+        checksum = self.web3.to_checksum_address(address)
+        return self.web3.eth.contract(address=checksum, abi=abi)
+
+    async def sign_and_send_transaction(
+        self, transaction: TxParams, timeout: int = 120, retries: int = 3
+    ) -> TxReceipt:
+        if "from" not in transaction:
+            transaction["from"] = self.account.address
+        if "nonce" not in transaction:
+            transaction["nonce"] = await self.web3.eth.get_transaction_count(self.account.address)
+        fee = await self.web3.eth.fee_history(1, "latest")
+        base_fee = fee["baseFeePerGas"][0]
+        priority = await self.web3.eth.max_priority_fee
+        transaction.setdefault("maxPriorityFeePerGas", priority)
+        transaction.setdefault("maxFeePerGas", base_fee + priority * 2)
+        for attempt in range(retries):
+            tx_hash = await self.web3.eth.send_transaction(transaction)
+            try:
+                receipt = await self.web3.eth.wait_for_transaction_receipt(tx_hash, timeout=timeout)
+            except TimeExhausted as exc:
+                if attempt == retries - 1:
+                    logger.error("Transaction %s timed out", tx_hash.hex())
+                    raise TransactionTimeoutError(str(exc))
+                delay = min(0.1 * 2**attempt, 30) + random.uniform(0, 0.05)
+                await asyncio.sleep(delay)
+                transaction["nonce"] = await self.web3.eth.get_transaction_count(self.account.address)
+                continue
+            if receipt["status"] == 0:
+                logger.error("Transaction %s failed", tx_hash.hex())
+                raise TransactionFailedError(f"Transaction {tx_hash.hex()} failed")
+            return receipt
+        raise TransactionTimeoutError("Max retries exceeded")

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,5 +1,12 @@
 """Security utilities for the trading bot."""
 
-from .key_manager import SecureKeyManager, secure_zero_memory
+from .key_manager import SecureKeyManager, locked_memory, secure_zero_memory
+from .secure_memory import lock_memory, unlock_memory
 
-__all__ = ["SecureKeyManager", "secure_zero_memory"]
+__all__ = [
+    "SecureKeyManager",
+    "secure_zero_memory",
+    "locked_memory",
+    "lock_memory",
+    "unlock_memory",
+]

--- a/security/secure_memory.py
+++ b/security/secure_memory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Memory locking and zeroing utilities."""
+
+import ctypes
+import sys
+from contextlib import contextmanager
+from typing import Iterator
+
+
+def secure_zero_memory(data: bytearray) -> None:
+    """Overwrite ``data`` with zeros."""
+    addr = ctypes.addressof(ctypes.c_char.from_buffer(data))
+    length = len(data)
+    if sys.platform == "win32":
+        ctypes.windll.kernel32.RtlSecureZeroMemory(addr, length)
+    else:
+        ctypes.memset(addr, 0, length)
+
+
+def lock_memory(data: bytearray) -> None:
+    """Prevent ``data`` from being swapped to disk."""
+    addr = ctypes.addressof(ctypes.c_char.from_buffer(data))
+    length = len(data)
+    if sys.platform == "win32":
+        ctypes.windll.kernel32.VirtualLock(addr, length)
+    else:
+        libc = ctypes.CDLL(None)
+        libc.mlock(addr, length)
+
+
+def unlock_memory(data: bytearray) -> None:
+    """Release memory lock on ``data``."""
+    addr = ctypes.addressof(ctypes.c_char.from_buffer(data))
+    length = len(data)
+    if sys.platform == "win32":
+        ctypes.windll.kernel32.VirtualUnlock(addr, length)
+    else:
+        libc = ctypes.CDLL(None)
+        libc.munlock(addr, length)
+
+
+@contextmanager
+def locked_memory(data: bytes) -> Iterator[memoryview]:
+    """Yield a locked memoryview of ``data`` and securely zero on exit."""
+    buf = bytearray(data)
+    lock_memory(buf)
+    try:
+        yield memoryview(buf)
+    finally:
+        secure_zero_memory(buf)
+        unlock_memory(buf)

--- a/tests/test_async_web3_service.py
+++ b/tests/test_async_web3_service.py
@@ -1,0 +1,67 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from web3.exceptions import TimeExhausted
+
+from async_web3_service import (
+    AsyncWeb3Service,
+    TransactionFailedError,
+    TransactionTimeoutError,
+)
+
+
+def _mock_service() -> AsyncWeb3Service:
+    service = AsyncWeb3Service.__new__(AsyncWeb3Service)
+    service.web3 = MagicMock()
+    eth = MagicMock()
+    eth.get_transaction_count = AsyncMock(return_value=1)
+    eth.send_transaction = AsyncMock(return_value=b"hash")
+    eth.wait_for_transaction_receipt = AsyncMock(return_value={"status": 1})
+    class _PriorityFee:
+        def __await__(self):
+            async def coro():
+                return 1
+            return coro().__await__()
+
+    eth.max_priority_fee = _PriorityFee()
+    eth.fee_history = AsyncMock(return_value={"baseFeePerGas": [1]})
+    service.web3.eth = eth
+    service.account = MagicMock(address="0xabc")
+    return service
+
+
+@pytest.mark.asyncio
+async def test_sign_and_send_success():
+    service = _mock_service()
+    receipt = await service.sign_and_send_transaction({})
+    assert receipt["status"] == 1
+    args, _ = service.web3.eth.send_transaction.call_args
+    assert "maxFeePerGas" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_sign_and_send_failure_status_zero():
+    service = _mock_service()
+    service.web3.eth.wait_for_transaction_receipt.return_value = {"status": 0}
+    with pytest.raises(TransactionFailedError):
+        await service.sign_and_send_transaction({})
+
+
+@pytest.mark.asyncio
+async def test_sign_and_send_timeout_then_raises():
+    service = _mock_service()
+    service.web3.eth.wait_for_transaction_receipt.side_effect = TimeExhausted
+    with pytest.raises(TransactionTimeoutError):
+        await service.sign_and_send_transaction({}, timeout=0.1, retries=2)
+
+
+@pytest.mark.asyncio
+async def test_sign_and_send_timeout_then_success():
+    service = _mock_service()
+    service.web3.eth.wait_for_transaction_receipt.side_effect = [
+        TimeExhausted,
+        {"status": 1},
+    ]
+    receipt = await service.sign_and_send_transaction({}, timeout=0.1, retries=2)
+    assert receipt["status"] == 1

--- a/tests/test_secure_memory.py
+++ b/tests/test_secure_memory.py
@@ -1,0 +1,18 @@
+import pytest
+
+from security.secure_memory import locked_memory, secure_zero_memory
+
+
+def test_secure_zero_memory():
+    buf = bytearray(b"secret")
+    secure_zero_memory(buf)
+    assert all(b == 0 for b in buf)
+
+
+def test_locked_memory_zeroes_on_exit():
+    try:
+        with locked_memory(b"secret") as mem:
+            assert bytes(mem) == b"secret"
+        assert bytes(mem) == b"\x00" * 6
+    except OSError:
+        pytest.skip("mlock not supported")


### PR DESCRIPTION
## Summary
- add secure async Web3 service using AsyncWeb3
- manage private keys in locked memory and zero on cleanup
- expose memory locking helpers
- update key manager to use locked memory
- test async Web3 service and secure memory utilities

## Testing
- `pytest tests/test_async_web3_service.py tests/test_secure_memory.py tests/test_key_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb427e3c832286e44bcb348ca724