### PR TITLE
Implement scoped OAuth2 auth

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -2,6 +2,7 @@
 
 from .key_manager import SecureKeyManager, locked_memory, secure_zero_memory
 from .secure_memory import lock_memory, unlock_memory
+from .async_auth import TokenData, get_current_user
 
 __all__ = [
     "SecureKeyManager",
@@ -9,4 +10,6 @@ __all__ = [
     "locked_memory",
     "lock_memory",
     "unlock_memory",
+    "get_current_user",
+    "TokenData",
 ]

--- a/security/async_auth.py
+++ b/security/async_auth.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Asynchronous OAuth2 bearer authentication utilities."""
+
+import os
+import secrets
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, SecurityScopes
+from jose import JWTError, jwt
+from pydantic import BaseModel
+
+SECRET_KEY = os.getenv("JWT_SECRET_KEY", secrets.token_urlsafe(32))
+ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="token",
+    scopes={
+        "trading": "Trading operations",
+        "high_value": "High value operations",
+        "admin": "Administrative operations",
+    },
+)
+
+
+class TokenData(BaseModel):
+    """Data stored in the JWT token."""
+
+    username: Optional[str] = None
+    scopes: list[str] = []
+
+
+async def get_current_user(
+    security_scopes: SecurityScopes,
+    token: str = Depends(oauth2_scheme),
+) -> TokenData:
+    """Validate JWT ``token`` and ensure required scopes are present."""
+
+    if security_scopes.scopes:
+        auth_header = f'Bearer scope="{security_scopes.scope_str}"'
+    else:
+        auth_header = "Bearer"
+    credentials_error = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": auth_header},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username = payload.get("sub")
+        token_scopes = payload.get("scopes", [])
+        if username is None:
+            raise credentials_error
+        if isinstance(token_scopes, str):
+            token_scopes = token_scopes.split()
+    except JWTError as exc:  # noqa: BLE001
+        raise credentials_error from exc
+    for scope in security_scopes.scopes:
+        if scope not in token_scopes:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not enough permissions",
+                headers={"WWW-Authenticate": auth_header},
+            )
+    return TokenData(username=username, scopes=token_scopes)
+
+
+__all__ = ["get_current_user", "TokenData"]

--- a/tests/test_api_analytics.py
+++ b/tests/test_api_analytics.py
@@ -2,11 +2,13 @@ from fastapi.testclient import TestClient
 from jose import jwt
 
 from api import app, risk_manager
-from api.auth import ALGORITHM, SECRET_KEY, UserRole
+from security.async_auth import ALGORITHM, SECRET_KEY
 
 
-def _token(role: UserRole = UserRole.TRADER) -> str:
-    payload = {"sub": "tester", "role": role.value}
+def _token(scopes: list[str] | None = None) -> str:
+    if scopes is None:
+        scopes = ["trading"]
+    payload = {"sub": "tester", "scopes": scopes}
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 client = TestClient(app)
@@ -37,16 +39,24 @@ def test_performance_endpoint():
     risk_manager.returns.clear()
     for r in [0.1, -0.05, 0.2]:
         risk_manager.update_equity(r)
-    headers = {"Authorization": f"Bearer {_token()}"}
-    resp = client.get("/analytics/performance", params={"confidence": 0.9}, headers=headers)
+    headers = {"Authorization": f"Bearer {_token(['high_value'])}"}
+    resp = client.get(
+        "/analytics/performance",
+        params={"confidence": 0.9},
+        headers=headers,
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert "var" in data and "sharpe" in data
 
 
 def test_performance_invalid_confidence():
-    headers = {"Authorization": f"Bearer {_token()}"}
-    resp = client.get("/analytics/performance", params={"confidence": 1.5}, headers=headers)
+    headers = {"Authorization": f"Bearer {_token(['high_value'])}"}
+    resp = client.get(
+        "/analytics/performance",
+        params={"confidence": 1.5},
+        headers=headers,
+    )
     assert resp.status_code == 400
 
 
@@ -56,7 +66,7 @@ def test_unauthorized_access():
 
 
 def test_forbidden_role():
-    headers = {"Authorization": f"Bearer {_token(UserRole.READ_ONLY)}"}
+    headers = {"Authorization": f"Bearer {_token(['trading'])}"}
     resp = client.get("/metrics", headers=headers)
     assert resp.status_code == 403
 

--- a/tests/test_async_auth.py
+++ b/tests/test_async_auth.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import SecurityScopes
+from jose import jwt
+
+from security.async_auth import ALGORITHM, SECRET_KEY, get_current_user
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_valid():
+    token = jwt.encode(
+        {"sub": "alice", "scopes": ["trading", "high_value"]},
+        SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+    scopes = SecurityScopes(scopes=["trading"])
+    user = await get_current_user(scopes, token)
+    assert user.username == "alice"
+    assert "trading" in user.scopes
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_missing_scope():
+    token = jwt.encode(
+        {"sub": "alice", "scopes": ["trading"]},
+        SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+    scopes = SecurityScopes(scopes=["admin"])
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(scopes, token)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_invalid_token():
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(SecurityScopes(), "badtoken")
+    assert exc.value.status_code == 401

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -5,7 +5,7 @@ import pytest
 from jose import jwt
 
 from api import app
-from api.auth import ALGORITHM, SECRET_KEY, UserRole
+from security.async_auth import ALGORITHM, SECRET_KEY
 from middleware.rate_limiter import RateLimiterMiddleware
 from utils.circuit_breaker import CircuitBreaker
 from utils.retry import retry_async
@@ -56,8 +56,10 @@ def test_rate_limit_and_health_endpoints():
     assert r.status_code == 429
 
 
-def _token(role: UserRole = UserRole.ADMIN) -> str:
-    return jwt.encode({"sub": "tester", "role": role.value}, SECRET_KEY, algorithm=ALGORITHM)
+def _token(scopes: list[str] | None = None) -> str:
+    if scopes is None:
+        scopes = ["admin"]
+    return jwt.encode({"sub": "tester", "scopes": scopes}, SECRET_KEY, algorithm=ALGORITHM)
 
 
 def test_metrics_endpoint():


### PR DESCRIPTION
## Summary
- add `security/async_auth.py` implementing OAuth2 bearer auth with scopes
- expose new auth helpers in `security/__init__`
- secure API endpoints using `Security` with scopes
- update tests to use scope-based tokens and add new tests for auth

## Testing
- `pytest -q tests/test_async_auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecfa1b3808322bce50e4ff2c1167b