### PR TITLE
Add async financial transaction validator with tests

### DIFF
--- a/tests/test_async_validators_module.py
+++ b/tests/test_async_validators_module.py
@@ -1,0 +1,86 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from models.trade_requests import EnhancedTradeRequest
+from trading.async_validators import (
+    AsyncFinancialTransactionValidator,
+    ValidationError,
+    RiskModelError,
+)
+
+
+@pytest.mark.asyncio
+async def test_validate_request_pass(monkeypatch):
+    validator = AsyncFinancialTransactionValidator()
+    monkeypatch.setattr(validator, "score_risk", AsyncMock(return_value=0.1))
+    req = EnhancedTradeRequest(token_pair=("0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"), amount=1.0, price=1.0)
+    assert await validator.validate_request(req)
+
+
+@pytest.mark.asyncio
+async def test_validate_request_high_risk(monkeypatch):
+    validator = AsyncFinancialTransactionValidator()
+    monkeypatch.setattr(validator, "score_risk", AsyncMock(return_value=0.9))
+    req = EnhancedTradeRequest(token_pair=("0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"), amount=1.0, price=1.0)
+    with pytest.raises(ValidationError):
+        await validator.validate_request(req)
+
+
+@pytest.mark.asyncio
+async def test_validate_request_timeout(monkeypatch):
+    validator = AsyncFinancialTransactionValidator(timeout=0.05)
+
+    async def slow_score(_: EnhancedTradeRequest) -> float:
+        await asyncio.sleep(0.1)
+        return 0.1
+
+    monkeypatch.setattr(validator, "score_risk", slow_score)
+    req = EnhancedTradeRequest(token_pair=("0x0000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000002"), amount=1.0, price=1.0)
+    with pytest.raises(RiskModelError):
+        await validator.validate_request(req)
+
+
+import os
+
+class DummyResp:
+    def __init__(self, score: float) -> None:
+        self.score = score
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return {"risk_score": self.score}
+
+class DummyClient:
+    def __init__(self, score: float) -> None:
+        self.score = score
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        pass
+
+    async def post(self, *_: str, **__: object) -> DummyResp:
+        return DummyResp(self.score)
+
+
+@pytest.mark.asyncio
+async def test_score_risk(monkeypatch):
+    os.environ["RISK_MODEL_URL"] = "http://test"
+    validator = AsyncFinancialTransactionValidator()
+    monkeypatch.setattr("httpx.AsyncClient", lambda timeout: DummyClient(0.3))
+    req = EnhancedTradeRequest(
+        token_pair=(
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+        ),
+        amount=1.0,
+        price=1.0,
+    )
+    score = await validator.score_risk(req)
+    assert score == 0.3
+

--- a/trading/__init__.py
+++ b/trading/__init__.py
@@ -1,0 +1,13 @@
+"""Trading utilities."""
+
+from .async_validators import (
+    AsyncFinancialTransactionValidator,
+    ValidationError,
+    RiskModelError,
+)
+
+__all__ = [
+    "AsyncFinancialTransactionValidator",
+    "ValidationError",
+    "RiskModelError",
+]

--- a/trading/async_validators.py
+++ b/trading/async_validators.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Asynchronous trade request validation utilities."""
+
+import asyncio
+import os
+from dataclasses import dataclass
+
+import httpx
+
+from models.trade_requests import EnhancedTradeRequest
+from utils.retry import retry_async
+from logger import get_logger
+
+
+logger = get_logger("async_validators")
+
+
+class ValidationError(Exception):
+    """Raised when a trade request fails validation."""
+
+
+class RiskModelError(Exception):
+    """Raised when risk scoring fails."""
+
+
+@dataclass
+class AsyncFinancialTransactionValidator:
+    """Validate trade requests using an external risk model."""
+
+    max_concurrent: int = int(os.getenv("VALIDATION_MAX_CONCURRENT", "5"))
+    timeout: float = float(os.getenv("VALIDATION_TIMEOUT", "5.0"))
+    threshold: float = float(os.getenv("RISK_THRESHOLD", "0.5"))
+
+    def __post_init__(self) -> None:
+        self._sem = asyncio.BoundedSemaphore(self.max_concurrent)
+
+    async def score_risk(self, request: EnhancedTradeRequest) -> float:
+        """Return a risk score for ``request`` between 0 and 1."""
+        url = os.getenv("RISK_MODEL_URL")
+        if not url:
+            raise RiskModelError("missing model url")
+        payload = request.model_dump()
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        return float(data.get("risk_score", 1.0))
+
+    async def validate_request(self, request: EnhancedTradeRequest) -> bool:
+        """Validate ``request`` asynchronously with retry and timeout."""
+        if not isinstance(request, EnhancedTradeRequest):
+            raise ValidationError("invalid request type")
+        async with self._sem:
+            try:
+                score = await asyncio.wait_for(
+                    retry_async(self.score_risk, request, retries=3),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError as exc:
+                logger.error("Risk scoring timed out: %s", exc)
+                raise RiskModelError("timeout") from exc
+            except Exception as exc:  # noqa: BLE001 - propagate as custom error
+                logger.error("Risk scoring failed: %s", exc)
+                raise RiskModelError(str(exc)) from exc
+        if score > self.threshold:
+            raise ValidationError("risk score too high")
+        return True


### PR DESCRIPTION
## Summary
- implement `AsyncFinancialTransactionValidator` with async rate-limited validation and risk scoring
- expose validator in new `trading` package
- add comprehensive tests for validator

## Testing
- `pytest tests/test_async_validators_module.py -q`
- `pytest --cov=trading.async_validators tests/test_async_validators_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed3558ae48322a41976222b17bbfb