### PR TITLE
Add Redis-based rate limiting

### DIFF
--- a/security/rate_limiting.py
+++ b/security/rate_limiting.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Asynchronous rate limiting utilities using Redis."""
+
+import asyncio
+import os
+from functools import wraps
+from typing import Any, Awaitable, Callable
+
+from fastapi import HTTPException, status
+from redis.asyncio import Redis
+
+from exceptions import RateLimitError
+from logger import get_logger
+from utils.retry import retry_async
+
+_logger = get_logger("rate_limiting")
+_client: Redis | None = None
+
+
+def get_redis() -> Redis:
+    """Return a cached Redis client instance."""
+    global _client
+    if _client is None:
+        _client = Redis(
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            db=int(os.getenv("REDIS_DB", "0")),
+            password=os.getenv("REDIS_PASSWORD"),
+            decode_responses=True,
+        )
+    return _client
+
+
+async def check_rate_limit(user_id: str, scope: str, limit: int, window: int) -> None:
+    """Increment request counter and enforce ``limit`` within ``window`` seconds."""
+    if not user_id or not scope or limit <= 0 or window <= 0:
+        raise RateLimitError("invalid parameters")
+    key = f"rl:{user_id}:{scope}"
+    timeout = float(os.getenv("REDIS_TIMEOUT", "5"))
+    client = get_redis()
+
+    async def _op() -> int:
+        count = await client.incr(key)
+        if count == 1:
+            await client.expire(key, window)
+        return int(count)
+
+    try:
+        count = await asyncio.wait_for(retry_async(_op), timeout)
+    except Exception as exc:  # noqa: BLE001
+        _logger.error("Rate limit check failed: %s", exc)
+        raise RateLimitError("rate limit check failed") from exc
+    if count > limit:
+        raise RateLimitError("request limit exceeded")
+
+
+def rate_limit(scope: str, limit: int, window: int) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorate FastAPI endpoints to enforce rate limits."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            user = kwargs.get("current_user")
+            username = getattr(user, "username", None)
+            if username is None:
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid user")
+            try:
+                await check_rate_limit(username, scope, limit, window)
+            except RateLimitError as exc:
+                raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, exc.message) from exc
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["rate_limit", "check_rate_limit", "get_redis"]

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,79 @@
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "security.rate_limiting", Path("security/rate_limiting.py")
+)
+rate_limiting = importlib.util.module_from_spec(spec)
+sys.modules["security.rate_limiting"] = rate_limiting
+assert spec.loader is not None
+spec.loader.exec_module(rate_limiting)
+from exceptions import RateLimitError
+
+
+class DummyRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+        self.expiry: dict[str, float] = {}
+
+    async def incr(self, key: str) -> int:
+        if key in self.expiry and self.expiry[key] <= time.time():
+            self.store.pop(key, None)
+            self.expiry.pop(key, None)
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    async def expire(self, key: str, seconds: int) -> None:
+        self.expiry[key] = time.time() + seconds
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client: DummyRedis) -> None:
+    monkeypatch.setattr(rate_limiting, "get_redis", lambda: client)
+
+
+def test_check_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = DummyRedis()
+    _patch_client(monkeypatch, client)
+    asyncio.run(rate_limiting.check_rate_limit("u", "s", 2, 1))
+    asyncio.run(rate_limiting.check_rate_limit("u", "s", 2, 1))
+    assert client.store["rl:u:s"] == 2
+
+
+def test_rate_limit_exceeded(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = DummyRedis()
+    _patch_client(monkeypatch, client)
+    asyncio.run(rate_limiting.check_rate_limit("u", "s", 1, 1))
+    with pytest.raises(RateLimitError):
+        asyncio.run(rate_limiting.check_rate_limit("u", "s", 1, 1))
+
+
+def test_rate_limit_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = DummyRedis()
+    _patch_client(monkeypatch, client)
+    asyncio.run(rate_limiting.check_rate_limit("u", "s", 1, 1))
+    time.sleep(1.1)
+    asyncio.run(rate_limiting.check_rate_limit("u", "s", 1, 1))
+    assert client.store["rl:u:s"] == 1
+
+
+def test_decorator(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = DummyRedis()
+    _patch_client(monkeypatch, client)
+
+    @rate_limiting.rate_limit("s", 1, 1)
+    async def handler(current_user):
+        return "ok"
+
+    user = SimpleNamespace(username="u")
+    assert asyncio.run(handler(current_user=user)) == "ok"
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(handler(current_user=user))
+    assert exc.value.status_code == 429


### PR DESCRIPTION
## Summary
- implement asynchronous Redis-backed rate limiting decorator
- ensure request counters reset via Redis expiry
- add unit tests for rate limiting utilities

## Testing
- `pytest -q tests/test_rate_limiting.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed50dced48322b068e029d2ccfe68