### PR TITLE
Add async audit logger with encryption

### DIFF
--- a/audit/__init__.py
+++ b/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Audit logging utilities."""
+
+from .async_audit_logger import AsyncAuditLogger
+
+__all__ = ["AsyncAuditLogger"]

--- a/audit/async_audit_logger.py
+++ b/audit/async_audit_logger.py
@@ -1,0 +1,117 @@
+"""Asynchronous audit logging with encryption and hashing."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, List, Sequence
+
+from cryptography.fernet import Fernet
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import AuditLog
+from database.services import DatabaseService
+from exceptions import DatabaseError
+from logger import get_logger, set_correlation_id
+from utils.circuit_breaker import CircuitBreaker
+from utils.retry import retry_async
+
+
+class AsyncAuditLogger:
+    """Persist encrypted audit records with correlation IDs."""
+
+    def __init__(self, db: DatabaseService, encryption_key: str) -> None:
+        if len(encryption_key) != 44:
+            raise ValueError("invalid Fernet key")
+        self._db = db
+        self._fernet = Fernet(encryption_key)
+        self.logger = get_logger("audit_logger")
+        self._circuit = CircuitBreaker()
+
+    def _encrypt(self, detail: str) -> tuple[str, str]:
+        data = detail.encode()
+        return (
+            self._fernet.encrypt(data).decode(),
+            hashlib.sha256(data).hexdigest(),
+        )
+
+    def _decrypt(self, data: str) -> str:
+        return self._fernet.decrypt(data.encode()).decode()
+
+    async def _save_batch(self, records: Sequence[AuditLog]) -> None:
+        async with self._db.transaction() as session:
+            session.add_all(list(records))
+            await session.flush()
+
+    async def insert_logs(
+        self,
+        entries: Iterable[tuple[str, str]],
+        correlation_id: str | None = None,
+        retries: int = 3,
+    ) -> str:
+        cid = set_correlation_id(correlation_id)
+        records: List[AuditLog] = []
+        for action, detail in entries:
+            if not action or not detail:
+                raise DatabaseError("invalid log entry")
+            enc, digest = self._encrypt(detail)
+            records.append(
+                AuditLog(
+                    correlation_id=cid,
+                    action=action,
+                    context=enc,
+                    context_hash=digest,
+                )
+            )
+
+        async def _op() -> None:
+            await self._save_batch(records)
+
+        try:
+            await self._circuit.call(
+                retry_async, _op, retries=retries
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Insert logs failed: %s", exc)
+            raise DatabaseError("audit insert failure") from exc
+        return cid
+
+    async def get_logs(
+        self,
+        correlation_id: str | None = None,
+        limit: int | None = None,
+        retries: int = 3,
+    ) -> List[dict]:
+        async def _op(session: AsyncSession) -> List[AuditLog]:
+            stmt = select(AuditLog)
+            if correlation_id:
+                stmt = stmt.where(AuditLog.correlation_id == correlation_id)
+            if limit:
+                stmt = stmt.limit(limit)
+            result = await session.execute(stmt)
+            return list(result.scalars())
+
+        async def _fetch() -> List[AuditLog]:
+            async with self._db.transaction() as session:
+                return await _op(session)
+
+        try:
+            records = await self._circuit.call(
+                retry_async, _fetch, retries=retries
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Fetch logs failed: %s", exc)
+            raise DatabaseError("audit fetch failure") from exc
+
+        return [
+            {
+                "action": r.action,
+                "details": self._decrypt(r.context),
+                "correlation_id": r.correlation_id,
+                "hash": r.context_hash,
+            }
+            for r in records
+        ]
+
+
+__all__ = ["AsyncAuditLogger"]

--- a/database/models/__init__.py
+++ b/database/models/__init__.py
@@ -31,8 +31,10 @@ class AuditLog(TimestampedModel):
 
     __tablename__ = "audit_log"
 
+    correlation_id: Mapped[str] = mapped_column(String(32), index=True)
     action: Mapped[str] = mapped_column(String(100))
     context: Mapped[str] = mapped_column(String)
+    context_hash: Mapped[str] = mapped_column(String(64))
 
 
 class PortfolioSnapshot(TimestampedModel):

--- a/tests/test_async_audit_logger.py
+++ b/tests/test_async_audit_logger.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from typing import Any
+import hashlib
+from sqlalchemy import select
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from audit import AsyncAuditLogger
+from config import DatabaseSettings
+from database.services import DatabaseService
+from database.models import Base, AuditLog
+from cryptography.fernet import Fernet
+
+
+@pytest.mark.asyncio
+async def test_insert_and_fetch(monkeypatch) -> None:
+    def fake_engine(url: str, **_: Any):
+        return create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine",
+        fake_engine,
+    )
+    settings = DatabaseSettings(
+        url="postgresql+asyncpg://user:pass@localhost/test",
+        encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+        audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+        query_timeout=30,
+    )
+    service = DatabaseService(settings)
+    async with service._engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    logger = AsyncAuditLogger(service, settings.audit_encryption_key)
+    logger._circuit = SimpleNamespace(call=lambda f, *a, **k: f(*a, **k))
+
+    cid = await logger.insert_logs([("login", "user admin")])
+    logs = await logger.get_logs(cid)
+    assert len(logs) == 1
+    assert logs[0]["action"] == "login"
+    assert logs[0]["details"] == "user admin"
+    async with service.transaction() as session:
+        stored = (await session.execute(select(AuditLog))).scalars().first()
+        assert stored.correlation_id == cid
+        assert stored.context_hash == hashlib.sha256(b"user admin").hexdigest()
+        assert (
+            Fernet(settings.audit_encryption_key)
+            .decrypt(stored.context.encode())
+            .decode()
+            == "user admin"
+        )
+
+
+@pytest.mark.asyncio
+async def test_insert_retry(monkeypatch) -> None:
+    def fake_engine(url: str, **_: Any):
+        return create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine",
+        fake_engine,
+    )
+    settings = DatabaseSettings(
+        url="postgresql+asyncpg://user:pass@localhost/test",
+        encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+        audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+        query_timeout=30,
+    )
+    service = DatabaseService(settings)
+    async with service._engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    logger = AsyncAuditLogger(service, settings.audit_encryption_key)
+    attempts = {"c": 0}
+
+    async def fail_then_pass(*args: Any, **kwargs: Any) -> None:
+        if attempts["c"] < 1:
+            attempts["c"] += 1
+            raise RuntimeError("boom")
+        await AsyncAuditLogger._save_batch(logger, *args, **kwargs)
+
+    monkeypatch.setattr(logger, "_save_batch", fail_then_pass)
+    logger._circuit = SimpleNamespace(call=lambda f, *a, **k: f(*a, **k))
+
+    cid = await logger.insert_logs([("act", "d")], retries=2)
+    assert attempts["c"] == 1
+    logs = await logger.get_logs(cid)
+    assert logs[0]["details"] == "d"


### PR DESCRIPTION
## Summary
- extend `AuditLog` model with correlation ID and context hash
- implement `AsyncAuditLogger` for encrypted audit logging with retry logic
- include unit tests for new async audit logger

## Testing
- `ruff check audit/async_audit_logger.py tests/test_async_audit_logger.py database/models/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee6fbdc908322a2fe33b31dd5ad95