### PR TITLE
Add AsyncFinancialAuditRecord model

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -6,6 +6,7 @@ from .models import (
     TradeExecution,
     StrategyPerformance,
     MarketDataCache,
+    AsyncFinancialAuditRecord,
 )
 from .repositories import BaseRepository, TradeRepository
 
@@ -15,6 +16,7 @@ __all__ = [
     "TradeExecution",
     "StrategyPerformance",
     "MarketDataCache",
+    "AsyncFinancialAuditRecord",
     "BaseRepository",
     "TradeRepository",
 ]

--- a/database/models/__init__.py
+++ b/database/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import Base, TimestampedModel
 from .trading import MarketDataCache, StrategyPerformance, TradeExecution
+from .audit_records import AsyncFinancialAuditRecord
 
 from datetime import datetime
 
@@ -65,5 +66,6 @@ __all__ = [
     "AuditLog",
     "PortfolioSnapshot",
     "RiskEvent",
+    "AsyncFinancialAuditRecord",
 ]
 

--- a/database/models/audit_records.py
+++ b/database/models/audit_records.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from sqlalchemy import Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import TimestampedModel
+
+
+class AsyncFinancialAuditRecord(TimestampedModel):
+    """Financial operation audit trail."""
+
+    __tablename__ = "async_financial_audit_record"
+    __table_args__ = (
+        Index("ix_async_financial_audit_record_created_at", "created_at"),
+        Index("ix_async_financial_audit_record_correlation_id", "correlation_id"),
+    )
+
+    operation_type: Mapped[str] = mapped_column(String(50))
+    data_encrypted: Mapped[str] = mapped_column(String)
+    hash: Mapped[str] = mapped_column(String(64))
+    correlation_id: Mapped[str] = mapped_column(String(32))
+
+
+__all__ = ["AsyncFinancialAuditRecord"]

--- a/tests/test_async_financial_audit_record.py
+++ b/tests/test_async_financial_audit_record.py
@@ -1,0 +1,50 @@
+import hashlib
+from typing import Any
+
+import pytest
+from sqlalchemy import inspect, select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from config import DatabaseSettings
+from database.models import Base, AsyncFinancialAuditRecord
+from database.services import DatabaseService
+
+
+@pytest.mark.asyncio
+async def test_financial_audit_record(monkeypatch) -> None:
+    def fake_engine(url: str, **_: Any):
+        return create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    monkeypatch.setattr(
+        "database.services.database.create_async_engine",
+        fake_engine,
+    )
+    settings = DatabaseSettings(
+        url="postgresql+asyncpg://user:pass@localhost/test",
+        encryption_key="8ZUJoRb_GXBDTPjL_Q0msBmE0vpo-hDabEIUkfGfs04=",
+        audit_encryption_key="oh-tvfXPINv_kIWFlUufdfrwqcoYlEtp6SuMziSRVLI=",
+        query_timeout=30,
+    )
+    service = DatabaseService(settings)
+    async with service._engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with service.transaction() as session:
+        record = AsyncFinancialAuditRecord(
+            operation_type="deposit",
+            data_encrypted="secret",
+            hash=hashlib.sha256(b"secret").hexdigest(),
+            correlation_id="cid1",
+        )
+        session.add(record)
+        await session.flush()
+        fetched = (
+            await session.execute(select(AsyncFinancialAuditRecord))
+        ).scalars().first()
+        assert fetched is not None and fetched.operation_type == "deposit"
+    async with service._engine.begin() as conn:
+        indexes = await conn.run_sync(
+            lambda c: inspect(c).get_indexes("async_financial_audit_record")
+        )
+    cols = {tuple(idx["column_names"]) for idx in indexes}
+    assert ("created_at",) in cols
+    assert ("correlation_id",) in cols


### PR DESCRIPTION
## Summary
- add AsyncFinancialAuditRecord ORM model
- expose the model via the database package
- test audit record model and indexes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eee74fb48832286e9a0eed53eda90