### PR TITLE
Refactor main helpers and config globals

### DIFF
--- a/config.py
+++ b/config.py
@@ -222,53 +222,65 @@ class ConfigManager:
         return self._config
 
 
+GLOBAL_ATTRS: dict[str, str | tuple[str, ...]] = {
+    "RPC_URL": "rpc_url",
+    "ENCRYPTED_PRIVATE_KEY": "encrypted_private_key",
+    "WALLET_ADDRESS": "wallet_address",
+    "TOKEN0_ADDRESS": "token0_address",
+    "TOKEN1_ADDRESS": "token1_address",
+    "UNISWAP_V2_ROUTER": "uniswap_v2_router",
+    "SUSHISWAP_ROUTER": "sushiswap_router",
+    "UNISWAP_V3_QUOTER": "uniswap_v3_quoter",
+    "UNISWAP_V3_ROUTER": "uniswap_v3_router",
+    "CURVE_POOL": "curve_pool",
+    "BALANCER_VAULT": "balancer_vault",
+    "BALANCER_POOL_ID": "balancer_pool_id",
+    "PROFIT_THRESHOLD": "profit_threshold",
+    "POLL_INTERVAL_SECONDS": "poll_interval_seconds",
+    "SLIPPAGE_TOLERANCE_PERCENT": "slippage_tolerance_percent",
+    "MAX_POSITION_SIZE": ("trading", "max_position_size"),
+    "RISK_LIMIT": ("trading", "risk_limit"),
+    "MAX_DAILY_VOLUME": ("trading", "max_daily_volume"),
+    "MAX_DRAWDOWN_PERCENT": ("risk", "max_drawdown_percent"),
+    "STOP_LOSS_PERCENT": ("risk", "stop_loss_percent"),
+    "TAKE_PROFIT_PERCENT": ("risk", "take_profit_percent"),
+    "GAS_LIMIT": ("dex", "gas_limit"),
+    "TX_TIMEOUT": ("dex", "tx_timeout"),
+    "MEV_PROTECTION_ENABLED": ("mev", "enabled"),
+    "FLASHBOTS_URL": ("mev", "flashbots_url"),
+    "FORK_RPC_URL": ("mev", "fork_rpc_url"),
+    "DEVIATION_THRESHOLD": ("mev", "deviation_threshold"),
+    "BATCH_TRANSACTIONS_ENABLED": ("batch", "enabled"),
+    "MULTICALL_ADDRESS": ("batch", "multicall_address"),
+    "DYNAMIC_SLIPPAGE_ENABLED": ("slippage_protection", "dynamic_slippage_enabled"),
+    "MAX_SLIPPAGE_BPS": ("slippage_protection", "max_slippage_bps"),
+    "REBALANCE_THRESHOLD": ("portfolio", "rebalance_threshold"),
+    "MAX_PORTFOLIO_ASSETS": ("portfolio", "max_assets"),
+    "DATABASE__URL": ("database", "url"),
+    "DATABASE__POOL_SIZE": ("database", "pool_size"),
+    "DATABASE__MAX_OVERFLOW": ("database", "max_overflow"),
+    "DATABASE__POOL_TIMEOUT": ("database", "pool_timeout"),
+    "DATABASE__POOL_RECYCLE": ("database", "pool_recycle"),
+    "DATABASE__ECHO": ("database", "echo"),
+    "DATABASE__REQUIRE_SSL": ("database", "require_ssl"),
+    "DATABASE__ENCRYPTION_KEY": ("database", "encryption_key"),
+    "DATABASE__AUDIT_ENCRYPTION_KEY": ("database", "audit_encryption_key"),
+    "DATABASE__QUERY_TIMEOUT": ("database", "query_timeout"),
+}
+
+
+def _resolve_attr(cfg: AppConfig, path: str | tuple[str, ...]):
+    value = cfg
+    if isinstance(path, str):
+        return getattr(value, path)
+    for part in path:
+        value = getattr(value, part)
+    return value
+
+
 def _update_globals(cfg: AppConfig) -> None:
-    mapping = {
-        "RPC_URL": cfg.rpc_url,
-        "ENCRYPTED_PRIVATE_KEY": cfg.encrypted_private_key,
-        "WALLET_ADDRESS": cfg.wallet_address,
-        "TOKEN0_ADDRESS": cfg.token0_address,
-        "TOKEN1_ADDRESS": cfg.token1_address,
-        "UNISWAP_V2_ROUTER": cfg.uniswap_v2_router,
-        "SUSHISWAP_ROUTER": cfg.sushiswap_router,
-        "UNISWAP_V3_QUOTER": cfg.uniswap_v3_quoter,
-        "UNISWAP_V3_ROUTER": cfg.uniswap_v3_router,
-        "CURVE_POOL": cfg.curve_pool,
-        "BALANCER_VAULT": cfg.balancer_vault,
-        "BALANCER_POOL_ID": cfg.balancer_pool_id,
-        "PROFIT_THRESHOLD": cfg.profit_threshold,
-        "POLL_INTERVAL_SECONDS": cfg.poll_interval_seconds,
-        "SLIPPAGE_TOLERANCE_PERCENT": cfg.slippage_tolerance_percent,
-        "MAX_POSITION_SIZE": cfg.trading.max_position_size,
-        "RISK_LIMIT": cfg.trading.risk_limit,
-        "MAX_DAILY_VOLUME": cfg.trading.max_daily_volume,
-        "MAX_DRAWDOWN_PERCENT": cfg.risk.max_drawdown_percent,
-        "STOP_LOSS_PERCENT": cfg.risk.stop_loss_percent,
-        "TAKE_PROFIT_PERCENT": cfg.risk.take_profit_percent,
-        "GAS_LIMIT": cfg.dex.gas_limit,
-        "TX_TIMEOUT": cfg.dex.tx_timeout,
-        "MEV_PROTECTION_ENABLED": cfg.mev.enabled,
-        "FLASHBOTS_URL": cfg.mev.flashbots_url,
-        "FORK_RPC_URL": cfg.mev.fork_rpc_url,
-        "DEVIATION_THRESHOLD": cfg.mev.deviation_threshold,
-        "BATCH_TRANSACTIONS_ENABLED": cfg.batch.enabled,
-        "MULTICALL_ADDRESS": cfg.batch.multicall_address,
-        "DYNAMIC_SLIPPAGE_ENABLED": cfg.slippage_protection.dynamic_slippage_enabled,
-        "MAX_SLIPPAGE_BPS": cfg.slippage_protection.max_slippage_bps,
-        "REBALANCE_THRESHOLD": cfg.portfolio.rebalance_threshold,
-        "MAX_PORTFOLIO_ASSETS": cfg.portfolio.max_assets,
-        "DATABASE__URL": cfg.database.url,
-        "DATABASE__POOL_SIZE": cfg.database.pool_size,
-        "DATABASE__MAX_OVERFLOW": cfg.database.max_overflow,
-        "DATABASE__POOL_TIMEOUT": cfg.database.pool_timeout,
-        "DATABASE__POOL_RECYCLE": cfg.database.pool_recycle,
-        "DATABASE__ECHO": cfg.database.echo,
-        "DATABASE__REQUIRE_SSL": cfg.database.require_ssl,
-        "DATABASE__ENCRYPTION_KEY": cfg.database.encryption_key,
-        "DATABASE__AUDIT_ENCRYPTION_KEY": cfg.database.audit_encryption_key,
-        "DATABASE__QUERY_TIMEOUT": cfg.database.query_timeout,
-    }
-    globals().update(mapping)
+    for name, path in GLOBAL_ATTRS.items():
+        globals()[name] = _resolve_attr(cfg, path)
 
 
 CONFIG_MANAGER = ConfigManager()

--- a/tests/test_config_update_globals.py
+++ b/tests/test_config_update_globals.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+import config
+
+
+def make_cfg():
+    trading = SimpleNamespace(max_position_size=1.0, risk_limit=0.1, max_daily_volume=10.0)
+    risk = SimpleNamespace(max_drawdown_percent=1.0, stop_loss_percent=0.5, take_profit_percent=0.8)
+    dex = SimpleNamespace(gas_limit=30000, tx_timeout=60)
+    mev = SimpleNamespace(enabled=True, flashbots_url="http://x", fork_rpc_url="http://y", deviation_threshold=0.1)
+    batch = SimpleNamespace(enabled=True, multicall_address="0x5")
+    slippage = SimpleNamespace(dynamic_slippage_enabled=True, max_slippage_bps=50)
+    portfolio = SimpleNamespace(rebalance_threshold=0.1, max_assets=5)
+    database = SimpleNamespace(
+        url="sqlite:///:memory:",
+        pool_size=1,
+        max_overflow=2,
+        pool_timeout=5,
+        pool_recycle=10,
+        echo=False,
+        require_ssl=True,
+        encryption_key="a" * 44,
+        audit_encryption_key="b" * 44,
+        query_timeout=30,
+    )
+    return SimpleNamespace(
+        rpc_url="rpc",
+        encrypted_private_key="enc",
+        wallet_address="0x1",
+        token0_address="0x2",
+        token1_address="0x3",
+        uniswap_v2_router="0x4",
+        sushiswap_router="0x5",
+        uniswap_v3_quoter="0x6",
+        uniswap_v3_router="0x7",
+        curve_pool="0x8",
+        balancer_vault="0x9",
+        balancer_pool_id="pid",
+        profit_threshold=1.0,
+        poll_interval_seconds=1,
+        slippage_tolerance_percent=0.5,
+        trading=trading,
+        risk=risk,
+        dex=dex,
+        mev=mev,
+        batch=batch,
+        slippage_protection=slippage,
+        portfolio=portfolio,
+        database=database,
+    )
+
+
+def test_update_globals_round_trip():
+    original = config.cfg
+    new_cfg = make_cfg()
+    config._update_globals(new_cfg)
+    assert config.RPC_URL == "rpc"
+    assert config.MAX_POSITION_SIZE == 1.0
+    assert config.DATABASE__POOL_SIZE == 1
+    config._update_globals(original)
+

--- a/tests/test_main_async.py
+++ b/tests/test_main_async.py
@@ -7,32 +7,49 @@ os.environ.setdefault("TOKEN1_ADDRESS", "0x0000000000000000000000000000000000000
 os.environ.setdefault("UNISWAP_V2_ROUTER", "0x0000000000000000000000000000000000000003")
 os.environ.setdefault("SUSHISWAP_ROUTER", "0x0000000000000000000000000000000000000004")
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 import main
 
 
-def test_main_runs(monkeypatch):
-    os.environ.setdefault("RPC_URL", "http://localhost")
-    os.environ.setdefault("ENCRYPTED_PRIVATE_KEY", "encrypted")
-    os.environ.setdefault("WALLET_ADDRESS", "0x0000000000000000000000000000000000000005")
+def test_setup_web3_service(monkeypatch):
+    svc = MagicMock()
+    monkeypatch.setattr(main, "Web3Service", MagicMock(return_value=svc))
+    result = main.setup_web3_service()
+    assert result is svc
 
-    monkeypatch.setattr(main, "Web3Service", MagicMock())
-    monkeypatch.setattr(main, "DEXHandler", MagicMock())
 
+def test_setup_dex_handlers(monkeypatch):
+    svc = MagicMock()
+    handler = MagicMock()
+    monkeypatch.setattr(main, "DEXHandler", MagicMock(return_value=handler))
+    handlers = main.setup_dex_handlers(svc)
+    assert handlers == [handler, handler]
+    main.DEXHandler.assert_any_call(svc, main.config.UNISWAP_V2_ROUTER)
+    main.DEXHandler.assert_any_call(svc, main.config.SUSHISWAP_ROUTER)
+
+
+@pytest.mark.asyncio
+async def test_launch_strategy(monkeypatch):
     strategy = MagicMock()
     strategy.run = AsyncMock()
     monkeypatch.setattr(main, "ArbitrageStrategy", MagicMock(return_value=strategy))
+    await main.launch_strategy([MagicMock()])
+    strategy.run.assert_awaited_once()
 
-    def fake_run(coro):
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
 
-    monkeypatch.setattr(main, "asyncio", MagicMock(run=fake_run))
+def test_main_runs(monkeypatch):
+    svc = MagicMock()
+    handlers = [MagicMock()]
+    monkeypatch.setattr(main, "setup_web3_service", MagicMock(return_value=svc))
+    monkeypatch.setattr(main, "setup_dex_handlers", MagicMock(return_value=handlers))
+    launch = AsyncMock()
+    monkeypatch.setattr(main, "launch_strategy", launch)
 
     main.main()
-    strategy.run.assert_awaited_once()
+
+    main.setup_web3_service.assert_called_once()
+    main.setup_dex_handlers.assert_called_once_with(svc)
+    launch.assert_awaited_once_with(handlers)


### PR DESCRIPTION
## Summary
- break main startup logic into smaller helpers
- update `_update_globals` to iterate over attribute mapping
- test new helper functions and global update logic

## Testing
- `pytest tests/test_main_async.py tests/test_config_update_globals.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3dfbd8c483228ba10504438dcc8a